### PR TITLE
Problem (Fix #103) : Fix warnings about memory leak on some components and pages 

### DIFF
--- a/src/components/PasswordForm/PasswordFormContainer.tsx
+++ b/src/components/PasswordForm/PasswordFormContainer.tsx
@@ -43,13 +43,13 @@ const PasswordFormContainer: React.FC<PasswordFormPageProps> = props => {
   const [validationErrMsg, setValidatorErrMsg] = useState<string>();
   const [resultButtonText, setResultButtonText] = useState<string>();
 
-  const onModalFinish = async () => {
+  const onModalFinish = () => {
     if (validationErrMsg !== '') {
       setValidatorErrMsg('');
       setDisplayComponent('form');
       return;
     }
-    await props.onSuccess(appPassword!);
+    props.onSuccess(appPassword!);
     setDisplayComponent('form');
   };
   const onModalCancel = () => {


### PR DESCRIPTION
So far I only see this warning during password creation, in PasswordFormContainer. Anywhere else? 
<img width="821" alt="螢幕截圖 2020-12-19 上午1 50 21" src="https://user-images.githubusercontent.com/74586409/102645206-100eac00-419d-11eb-88d0-2b021dad43f9.png">
