### PR TITLE
Avoid temp seed DB persistence - Use recoil for temporary state and flush it after backup

### DIFF
--- a/src/models/Wallet.ts
+++ b/src/models/Wallet.ts
@@ -52,6 +52,11 @@ export interface CustomConfigFormValue {
   indexingUrl: string;
 }
 
+export function setPhrase(wallet: Wallet, phrase: string): Wallet {
+  wallet.encryptedPhrase = phrase;
+  return wallet;
+}
+
 export function reconstructCustomConfig(formValues: CustomConfigFormValue): WalletConfig {
   const customNetwork: Network = {
     addressPrefix: formValues.addressPrefix,

--- a/src/models/Wallet.ts
+++ b/src/models/Wallet.ts
@@ -52,11 +52,6 @@ export interface CustomConfigFormValue {
   indexingUrl: string;
 }
 
-export function setPhrase(wallet: Wallet, phrase: string): Wallet {
-  wallet.encryptedPhrase = phrase;
-  return wallet;
-}
-
 export function reconstructCustomConfig(formValues: CustomConfigFormValue): WalletConfig {
   const customNetwork: Network = {
     addressPrefix: formValues.addressPrefix,

--- a/src/pages/backup/backup.tsx
+++ b/src/pages/backup/backup.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { useRecoilValue } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import './backup.less';
 import { Button, Checkbox } from 'antd';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import MouseTooltip from 'react-sticky-mouse-tooltip';
-import { walletIdentifierState } from '../../recoil/atom';
-import { Wallet } from '../../models/Wallet';
+import { walletIdentifierState, walletTempBackupSeedState } from '../../recoil/atom';
+import { setPhrase, Wallet } from '../../models/Wallet';
 import { walletService } from '../../service/WalletService';
 import logo from '../../assets/logo-products-chain.svg';
 import ErrorModalPopup from '../../components/ErrorModalPopup/ErrorModalPopup';
@@ -20,6 +20,7 @@ function BackupPage() {
   const [wallet, setWallet] = useState<Wallet>();
   const [isErrorModalVisible, setIsErrorModalVisible] = useState(false);
   const walletIdentifier: string = useRecoilValue(walletIdentifierState);
+  const [walletTempBackupSeed, setWalletTempBackupSeed] = useRecoilState(walletTempBackupSeedState);
   const didMountRef = useRef(false);
   const history = useHistory();
   const [inputPasswordVisible, setInputPasswordVisible] = useState(false);
@@ -35,6 +36,9 @@ function BackupPage() {
     }
     await walletService.encryptWalletAndSetSession(password, wallet);
     setGoHomeButtonLoading(false);
+
+    // Flush recoil state - remove temporary seed values
+    setWalletTempBackupSeed({ seed: '', walletId: '' });
     history.push('/home');
   };
 
@@ -60,8 +64,9 @@ function BackupPage() {
 
   const fetchWallet = async () => {
     const fetchedWallet = await walletService.findWalletByIdentifier(walletIdentifier);
-    if (fetchedWallet !== null) {
-      setWallet(fetchedWallet);
+    if (fetchedWallet !== null && walletIdentifier === walletTempBackupSeed.walletId) {
+      const updatedWallet = setPhrase(fetchedWallet, walletTempBackupSeed.seed);
+      setWallet(updatedWallet);
     } else {
       showErrorModal();
     }

--- a/src/pages/create/create.tsx
+++ b/src/pages/create/create.tsx
@@ -3,9 +3,9 @@ import { useHistory } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 import { Button, Form, Input, Select } from 'antd';
 import { FormInstance } from 'antd/lib/form';
-import { walletIdentifierState, walletTempBackupSeedState } from '../../recoil/atom';
+import { walletIdentifierState, walletTempBackupState } from '../../recoil/atom';
 import './create.less';
-import { setPhrase, Wallet } from '../../models/Wallet';
+import { Wallet } from '../../models/Wallet';
 import { walletService } from '../../service/WalletService';
 import { WalletCreateOptions, WalletCreator } from '../../service/WalletCreator';
 import { DefaultWalletConfigs } from '../../config/StaticConfig';
@@ -235,7 +235,7 @@ const FormCreate: React.FC<FormCreateProps> = props => {
   const [createLoading, setCreateLoading] = useState(false);
   const [wallet, setWallet] = useState<Wallet>();
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [walletTempBackupSeed, setWalletTempBackupSeed] = useRecoilState(walletTempBackupSeedState);
+  const [walletTempBackupSeed, setWalletTempBackupSeed] = useRecoilState(walletTempBackupState);
 
   const showModal = () => {
     setIsModalVisible(true);
@@ -299,15 +299,7 @@ const FormCreate: React.FC<FormCreateProps> = props => {
 
     try {
       const createdWallet = WalletCreator.create(createOptions);
-      setWalletTempBackupSeed({
-        walletId: createdWallet.identifier,
-        seed: createdWallet.encryptedPhrase,
-      });
-      // Clean phrase before on-disk (NeDB) persistence
-      const safeTemporaryWallet = setPhrase(createdWallet, '');
-
-      // The temporarily persisted wallet doesn't have a plain text seed at this point
-      await walletService.persistWallet(safeTemporaryWallet);
+      setWalletTempBackupSeed(createdWallet);
 
       setWallet(createdWallet);
       setCreateLoading(false);

--- a/src/recoil/atom.tsx
+++ b/src/recoil/atom.tsx
@@ -39,17 +39,10 @@ const walletListState = atom({
   default: [wallet],
 });
 
-export interface TempBackupSeed {
-  walletId: string;
-  seed: string;
-}
-// Will hold the seed temporarily and will be flushed after backup phase
-const walletTempBackupSeedState = atom<TempBackupSeed>({
+// Will hold the wallet seed temporarily and will be flushed after backup phase
+const walletTempBackupState = atom<Wallet | null>({
   key: 'walletTempBackupSeed',
-  default: {
-    walletId: '',
-    seed: '',
-  },
+  default: null,
 });
 
 export {
@@ -57,5 +50,5 @@ export {
   sessionState,
   walletAssetState,
   walletListState,
-  walletTempBackupSeedState,
+  walletTempBackupState,
 };

--- a/src/recoil/atom.tsx
+++ b/src/recoil/atom.tsx
@@ -39,4 +39,23 @@ const walletListState = atom({
   default: [wallet],
 });
 
-export { walletIdentifierState, sessionState, walletAssetState, walletListState };
+export interface TempBackupSeed {
+  walletId: string;
+  seed: string;
+}
+// Will hold the seed temporarily and will be flushed after backup phase
+const walletTempBackupSeedState = atom<TempBackupSeed>({
+  key: 'walletTempBackupSeed',
+  default: {
+    walletId: '',
+    seed: '',
+  },
+});
+
+export {
+  walletIdentifierState,
+  sessionState,
+  walletAssetState,
+  walletListState,
+  walletTempBackupSeedState,
+};


### PR DESCRIPTION
### Problem

There's a scenario where the user might close the app just before completing the backup.
At that stage, the wallet is still persisted in plain text because wallet storage encryption only happens after the user has backup. 
In that scenario, the wallet can still be found in plain text in the indexedDB files

### Old Behaviour 

During wallet creation user flow, it used to happen in 2 steps :

Step 1: Persist on-disk(DB) temporary wallet data, here they were not encrypted yet since it still had to be used later for users to  backup

Step 2: When the backup is completed, the previously persisted wallet data was finally encrypted ( Its seed phrase )

### New Behaviour & Solution

Here there's no more temporary DB or disk persistence. It's now being kept in `recoil/memory` temporary storage and flushed afterward.

So now during creation UI flow, wallet creation only happens in 1 step compared to the previous 2 steps creation.