### PR TITLE
Prevent Big.js roundups - Keep good precision on floating point numbers presentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   "private": true,
   "dependencies": {
     "@ant-design/icons": "^4.3.0",
-    "@cosmjs/stargate": "^0.24.0-alpha.22",
     "@babel/helper-builder-react-jsx": "^7.10.4",
     "@babel/helper-builder-react-jsx-experimental": "^7.12.11",
+    "@cosmjs/stargate": "^0.24.0-alpha.22",
     "@crypto-com/chain-jslib": "^0.0.10",
     "@ledgerhq/hw-transport-node-hid": "^5.41.0",
     "@ledgerhq/hw-transport-webhid": "^5.38.0",
@@ -28,7 +28,9 @@
     "@types/react-router-dom": "^5.1.6",
     "antd": "^4.9.1",
     "axios": "^0.21.1",
+    "bech32": "^1.1.4",
     "bfj": "^7.0.2",
+    "big.js": "^6.0.3",
     "camelcase": "^6.1.0",
     "copyfiles": "^2.4.1",
     "crypto-js": "^4.0.0",
@@ -53,8 +55,7 @@
     "typescript": "4.0.5",
     "url-loader": "4.1.1",
     "usb": "^1.6.3",
-    "zxcvbn": "^4.4.2",
-    "bech32": "^1.1.4"
+    "zxcvbn": "^4.4.2"
   },
   "scripts": {
     "start": "node scripts/start.js",

--- a/src/utils/NumberUtils.spec.ts
+++ b/src/utils/NumberUtils.spec.ts
@@ -30,8 +30,10 @@ describe('Testing Number utils', () => {
     expect(getNormalScaleAmount('5000', asset)).to.eq('0.00005');
     expect(getNormalScaleAmount('524005000', asset)).to.eq('5.24005');
 
-    expect(getUINormalScaleAmount('2458999245545', asset.decimals)).to.eq('24589.9925');
-    expect(getUINormalScaleAmount('334005045600', asset.decimals)).to.eq('3340.0505');
+    expect(getUINormalScaleAmount('2458999245545', asset.decimals)).to.eq('24589.9924');
+    expect(getUINormalScaleAmount('334005045600', asset.decimals)).to.eq('3340.0504');
+
+    expect(getUINormalScaleAmount('499995000', asset.decimals)).to.eq('4.9999');
   });
 
   it('Test conversion from scientific notation', () => {

--- a/src/utils/NumberUtils.ts
+++ b/src/utils/NumberUtils.ts
@@ -1,6 +1,9 @@
+import { Big } from 'big.js';
 import { scaledBalance, UserAsset } from '../models/UserAsset';
-import { Big } from './ChainJsLib';
 import { FIXED_DEFAULT_FEE } from '../config/StaticConfig';
+
+// Here we are telling the library to NOT DO any rounding, either up or down
+Big.RM = 0;
 
 export function fromScientificNotation(value) {
   return Big(value).toFixed();


### PR DESCRIPTION
<img width="699" alt="Screen Shot 2021-02-24 at 4 50 34 PM" src="https://user-images.githubusercontent.com/73159521/109011226-ba391180-76c1-11eb-9bda-2c7b3c9e8a96.png">
<img width="1008" alt="Screen Shot 2021-02-24 at 4 51 29 PM" src="https://user-images.githubusercontent.com/73159521/109011237-bdcc9880-76c1-11eb-8373-18615330cb8f.png">

Fixes https://github.com/crypto-com/chain-desktop-wallet/issues/260
