### PR TITLE
Add workaround for executable library execution - Tell apple to ignore external lib signature checking

### DIFF
--- a/entitlements.mac.plist
+++ b/entitlements.mac.plist
@@ -16,5 +16,7 @@
         <true/>
         <key>com.apple.security.files.user-selected.read-write</key>
         <true/>
+        <key>com.apple.security.cs.disable-library-validation</key>
+        <true/>
 	</dict>
 </plist>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chain-desktop-wallet",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "description": "Crypto.com Chain Desktop Wallet App",
   "repository": "github:crypto-com/chain-desktop-wallet",
   "author": "Crypto.com <chain@crypto.com>",


### PR DESCRIPTION
Trying this alternative https://github.com/electron-userland/electron-builder/issues/3940


Fixes https://github.com/crypto-com/chain-desktop-wallet/issues/279