### PR TITLE
Add a list of validators

### DIFF
--- a/src/models/Transaction.ts
+++ b/src/models/Transaction.ts
@@ -63,3 +63,11 @@ export interface ValidatorModel {
   readonly currentCommissionRate: string;
   readonly currentShares: string;
 }
+
+export interface ValidatorModelExtended {
+  readonly validatorName: string;
+  readonly validatorAddress: string;
+  readonly currentCommissionRate: string;
+  readonly maxCommissionRate: string;
+  readonly currentShares: string;
+}

--- a/src/service/WalletService.ts
+++ b/src/service/WalletService.ts
@@ -34,6 +34,7 @@ import {
   TransferTransactionData,
   TransferTransactionList,
   ValidatorModel,
+  ValidatorModelExtended,
 } from '../models/Transaction';
 import { ChainIndexingAPI } from './rpc/ChainIndexingAPI';
 import { getBaseScaledAmount } from '../utils/NumberUtils';
@@ -695,6 +696,21 @@ class WalletService {
       }
       const nodeRpc = await NodeRpcService.init(currentSession.wallet.config.nodeUrl);
       return nodeRpc.loadTopValidators();
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.log('FAILED_LOADING TOP VALIDATORS', e);
+      return [];
+    }
+  }
+
+  public async getBondedValidators(): Promise<ValidatorModelExtended[]> {
+    try {
+      const currentSession = await this.storageService.retrieveCurrentSession();
+      if (currentSession?.wallet.config.nodeUrl === NOT_KNOWN_YET_VALUE) {
+        return Promise.resolve([]);
+      }
+      const nodeRpc = await NodeRpcService.init(currentSession.wallet.config.nodeUrl);
+      return nodeRpc.loadBondedValidators();
     } catch (e) {
       // eslint-disable-next-line no-console
       console.log('FAILED_LOADING TOP VALIDATORS', e);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2001818/112303640-7d1f6980-8cd7-11eb-83f3-0478d9aa457f.png)

Adds a page in staking view to show the existing validators. It is not perfect, and some code might be duplicated but let me know how I can change it! Also, this is just limited to 1 page as of now.

Could improve it with more pages and maybe a button to instantly stake with the validator on the list.

Hope it helps!