### PR TITLE
Feature (Fix #458): show all decimals of staked & total balances

### DIFF
--- a/src/models/UserAsset.ts
+++ b/src/models/UserAsset.ts
@@ -45,8 +45,16 @@ export const scaledBalance = (asset: UserAsset) => {
   return getUINormalScaleAmount(asset.balance, asset.decimals);
 };
 
+export const scaledBalanceFull = (asset: UserAsset) => {
+  return getUINormalScaleAmount(asset.balance, asset.decimals, asset.decimals);
+};
+
 export const scaledStakingBalance = (asset: UserAsset) => {
   return getUINormalScaleAmount(asset.stakedBalance, asset.decimals);
+};
+
+export const scaledStakingBalanceFull = (asset: UserAsset) => {
+  return getUINormalScaleAmount(asset.stakedBalance, asset.decimals, asset.decimals);
 };
 
 export const getAssetPriceIdFrom = (assetSymbol: string, currency: string) => {

--- a/src/pages/home/home.less
+++ b/src/pages/home/home.less
@@ -16,7 +16,7 @@
     }
 
     .quantity {
-      font-size: 24px;
+      font-size: 23px;
     }
 
     .fiat {

--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -37,7 +37,10 @@ import ErrorModalPopup from '../../components/ErrorModalPopup/ErrorModalPopup';
 import { NOT_KNOWN_YET_VALUE, WalletConfig } from '../../config/StaticConfig';
 import { UndelegateFormComponent } from './components/UndelegateFormComponent';
 import { RedelegateFormComponent } from './components/RedelegateFormComponent';
-import { getUIDynamicAmount } from '../../utils/NumberUtils';
+import {
+  getUIDynamicAmount,
+  getFormattedAmount
+} from '../../utils/NumberUtils';
 import { middleEllipsis } from '../../utils/utils';
 import { LEDGER_WALLET_TYPE, detectConditionsError } from '../../service/LedgerService';
 
@@ -512,7 +515,7 @@ function HomePage() {
           <div className="balance">
             <div className="title">TOTAL BALANCE</div>
             <div className="quantity">
-              {numeral(scaledBalanceFull(userAsset)).format('0,0.[00000000]')} {userAsset?.symbol}
+              {getFormattedAmount(scaledBalanceFull(userAsset))} {userAsset?.symbol}
             </div>
             <div className="fiat">
               {marketData && marketData.price
@@ -525,7 +528,7 @@ function HomePage() {
           <div className="balance">
             <div className="title">STAKED BALANCE</div>
             <div className="quantity">
-              {numeral(scaledStakingBalanceFull(userAsset)).format('0,0.[00000000]')} {userAsset?.symbol}
+              {getFormattedAmount(scaledStakingBalanceFull(userAsset))} {userAsset?.symbol}
             </div>
             <div className="fiat">
               {marketData && marketData.price

--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -512,7 +512,7 @@ function HomePage() {
           <div className="balance">
             <div className="title">TOTAL BALANCE</div>
             <div className="quantity">
-              {numeral(scaledBalance(userAsset)).format('0,0.0000')} {userAsset?.symbol}
+              {numeral(scaledBalance(userAsset)).format('0,0.[00000000]')} {userAsset?.symbol}
             </div>
             <div className="fiat">
               {marketData && marketData.price
@@ -525,7 +525,7 @@ function HomePage() {
           <div className="balance">
             <div className="title">STAKED BALANCE</div>
             <div className="quantity">
-              {numeral(scaledStakingBalance(userAsset)).format('0,0.0000')} {userAsset?.symbol}
+              {numeral(scaledStakingBalance(userAsset)).format('0,0.[00000000]')} {userAsset?.symbol}
             </div>
             <div className="fiat">
               {marketData && marketData.price

--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -6,8 +6,8 @@ import { SyncOutlined } from '@ant-design/icons';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import numeral from 'numeral';
 import {
-  scaledBalance,
-  scaledStakingBalance,
+  scaledBalanceFull,
+  scaledStakingBalanceFull,
   getAssetBalancePrice,
   getAssetStakingBalancePrice,
   UserAsset,
@@ -512,7 +512,7 @@ function HomePage() {
           <div className="balance">
             <div className="title">TOTAL BALANCE</div>
             <div className="quantity">
-              {numeral(scaledBalance(userAsset)).format('0,0.[00000000]')} {userAsset?.symbol}
+              {numeral(scaledBalanceFull(userAsset)).format('0,0.[00000000]')} {userAsset?.symbol}
             </div>
             <div className="fiat">
               {marketData && marketData.price
@@ -525,7 +525,7 @@ function HomePage() {
           <div className="balance">
             <div className="title">STAKED BALANCE</div>
             <div className="quantity">
-              {numeral(scaledStakingBalance(userAsset)).format('0,0.[00000000]')} {userAsset?.symbol}
+              {numeral(scaledStakingBalanceFull(userAsset)).format('0,0.[00000000]')} {userAsset?.symbol}
             </div>
             <div className="fiat">
               {marketData && marketData.price

--- a/src/utils/NumberUtils.spec.ts
+++ b/src/utils/NumberUtils.spec.ts
@@ -90,4 +90,12 @@ describe('Testing Number utils', () => {
     expect(adjustedTransactionAmount('0.245', asset, networkFee)).to.eq('0.2449');
     expect(adjustedTransactionAmount('0.1223', asset, networkFee)).to.eq('0.1223');
   });
+  
+  it('Test amount formatting', () => {
+    expect(getFormattedAmount('123456789.12345678')).to.eq('123,456,789.12345678');
+    expect(getFormattedAmount('123456789.00100')).to.eq('123,456,789.001');
+    expect(getFormattedAmount('12345678.001001')).to.eq('12,345,678.001001');
+    expect(getFormattedAmount('0.0000')).to.eq('0');
+    expect(getFormattedAmount('1.0000')).to.eq('1');
+  });
 });

--- a/src/utils/NumberUtils.spec.ts
+++ b/src/utils/NumberUtils.spec.ts
@@ -7,6 +7,7 @@ import {
   getNormalScaleAmount,
   getUIDynamicAmount,
   getUINormalScaleAmount,
+  getFormattedAmount
 } from './NumberUtils';
 import { UserAsset } from '../models/UserAsset';
 import { DefaultWalletConfigs } from '../config/StaticConfig';

--- a/src/utils/NumberUtils.ts
+++ b/src/utils/NumberUtils.ts
@@ -116,16 +116,19 @@ export function adjustedTransactionAmount(
 }
 
 export function getFormattedAmount(amount: string): string {
-  // replace hardcoded separators if/when localization is available
+  // replace hardcoded separators when localization is available
   const decimalSeparator = '.';
   const thousandSeparator = ',';
 
   const elements = amount.split(decimalSeparator);
-  let integers = elements[0];
-  const decimals = elements.length > 1 ? decimalSeparator + elements[1].replace(/[0]+$/, '') : '';
+  let result = elements[0];
+  const decimals = elements.length > 1 ? elements[1].replace(/[0]+$/, '') : '';
   const rgxThousand = /(\d+)(\d{3})/;
-  while (rgxThousand.test(integers)) {
-    integers = integers.replace(rgxThousand, `$1${thousandSeparator}$2`);
+  while (rgxThousand.test(result)) {
+    result = result.replace(rgxThousand, `$1${thousandSeparator}$2`);
   }
-  return integers + decimals;
+  if (decimals.length > 0) {
+    result = result + decimalSeparator + decimals;
+  }
+  return result;
 }

--- a/src/utils/NumberUtils.ts
+++ b/src/utils/NumberUtils.ts
@@ -114,3 +114,18 @@ export function adjustedTransactionAmount(
   }
   return formAmount;
 }
+
+export function getFormattedAmount(amount: string): string {
+  // replace hardcoded separators if/when localization is available
+  const decimalSeparator = '.';
+  const thousandSeparator = ',';
+
+  const elements = amount.split(decimalSeparator);
+  let integers = elements[0];
+  const decimals = elements.length > 1 ? decimalSeparator + elements[1].replace(/[0]+$/, '') : '';
+  const rgxThousand = /(\d+)(\d{3})/;
+  while (rgxThousand.test(integers)) {
+    integers = integers.replace(rgxThousand, `$1${thousandSeparator}$2`);
+  }
+  return integers + decimals;
+}


### PR DESCRIPTION
The wallet shows only 4 decimals on the home page when the explorer & DeFi wallet show all of them (8)
The new format will show all decimals when needed, for ex:
```
input -> output
0 -> 0
123.01000100 -> 123.010001
123 -> 123
123.00000000 -> 123
123.00000001 -> 123.00000001
1.0 -> 1
```

I hereby certify that my contribution is in accordance with the Developer Certificate of Origin (https://developercertificate.org/).