### PR TITLE
Wallet Deletion Optimization & add croeseid-3 label color

### DIFF
--- a/src/layouts/home/home.tsx
+++ b/src/layouts/home/home.tsx
@@ -30,6 +30,7 @@ import IconReceive from '../../svg/IconReceive';
 import IconStaking from '../../svg/IconStaking';
 import IconWallet from '../../svg/IconWallet';
 import ModalPopup from '../../components/ModalPopup/ModalPopup';
+import SuccessModalPopup from '../../components/SuccessModalPopup/SuccessModalPopup';
 import { walletService } from '../../service/WalletService';
 import { Session } from '../../models/Session';
 import packageJson from '../../../package.json';
@@ -57,6 +58,8 @@ function HomeLayout(props: HomeLayoutProps) {
   const [isButtonDisabled, setIsButtonDisabled] = useState(true);
   const [isConfirmDeleteVisible, setIsConfirmDeleteVisible] = useState(false);
   const [isConfirmationModalVisible, setIsConfirmationModalVisible] = useState(false);
+  const [isSuccessDeleteModalVisible, setIsSuccessDeleteModalVisible] = useState(false);
+
   const [isAnnouncementVisible, setIsAnnouncementVisible] = useState(false);
   const [isButtonLoading, setIsButtonLoading] = useState(false);
   const didMountRef = useRef(false);
@@ -100,6 +103,7 @@ function HomeLayout(props: HomeLayoutProps) {
 
     setIsButtonLoading(false);
     setIsConfirmationModalVisible(false);
+    setIsSuccessDeleteModalVisible(true);
     setFetchingDB(false);
     setIsButtonDisabled(true);
     setIsConfirmDeleteVisible(false);
@@ -380,6 +384,38 @@ function HomeLayout(props: HomeLayoutProps) {
             )}
           </>
         </ModalPopup>
+        <SuccessModalPopup
+          isModalVisible={isSuccessDeleteModalVisible}
+          handleCancel={() => {
+            setIsSuccessDeleteModalVisible(false);
+          }}
+          handleOk={() => {
+            setIsSuccessDeleteModalVisible(false);
+          }}
+          title="Success!"
+          button={null}
+          footer={[
+            <Button
+              key="submit"
+              type="primary"
+              onClick={() => {
+                setIsSuccessDeleteModalVisible(false);
+              }}
+            >
+              Ok
+            </Button>,
+          ]}
+        >
+          <>
+            <div className="description">
+              Wallet Address
+              <br />
+              {deleteWalletAddress}
+              <br />
+              has been deleted.
+            </div>
+          </>
+        </SuccessModalPopup>
         <ModalPopup
           isModalVisible={isAnnouncementVisible}
           handleCancel={() => {

--- a/src/layouts/home/home.tsx
+++ b/src/layouts/home/home.tsx
@@ -46,6 +46,7 @@ const { Sider } = Layout;
 function HomeLayout(props: HomeLayoutProps) {
   const history = useHistory();
   const [confirmDeleteForm] = Form.useForm();
+  const [deleteWalletAddress, setDeleteWalletAddress] = useState('');
   const [hasWallet, setHasWallet] = useState(true); // Default as true. useEffect will only re-render if result of hasWalletBeenCreated === false
   const [session, setSession] = useRecoilState(sessionState);
   const [userAsset, setUserAsset] = useRecoilState(walletAssetState);
@@ -106,11 +107,13 @@ function HomeLayout(props: HomeLayoutProps) {
   };
 
   const handleCancel = () => {
-    setIsConfirmationModalVisible(false);
-    setIsConfirmDeleteVisible(false);
-    setIsButtonDisabled(true);
-    setIsConfirmDeleteVisible(false);
-    confirmDeleteForm.resetFields();
+    if (!isButtonLoading) {
+      setIsConfirmationModalVisible(false);
+      setIsConfirmDeleteVisible(false);
+      setIsButtonDisabled(true);
+      setIsConfirmDeleteVisible(false);
+      confirmDeleteForm.resetFields();
+    }
   };
 
   const showPasswordModal = () => {
@@ -229,7 +232,10 @@ function HomeLayout(props: HomeLayoutProps) {
           <>
             <Menu.Item
               className="delete-wallet-item"
-              onClick={() => setIsConfirmationModalVisible(true)}
+              onClick={() => {
+                setDeleteWalletAddress(session.wallet.address);
+                setIsConfirmationModalVisible(true);
+              }}
             >
               <DeleteOutlined />
               Delete Wallet
@@ -317,7 +323,8 @@ function HomeLayout(props: HomeLayoutProps) {
             <div className="description">Please review the below information. </div>
             <div className="item">
               <div className="label">Delete Wallet Address</div>
-              <div className="address">{`${session.wallet.address}`}</div>
+              {/* <div className="address">{`${session.wallet.address}`}</div> */}
+              <div className="address">{`${deleteWalletAddress}`}</div>
             </div>
             {!isConfirmDeleteVisible ? (
               <>
@@ -361,7 +368,7 @@ function HomeLayout(props: HomeLayoutProps) {
                         required: true,
                       },
                       {
-                        pattern: /DELETE/,
+                        pattern: /^DELETE$/,
                         message: 'Please enter DELETE',
                       },
                     ]}

--- a/src/pages/settings/settings.tsx
+++ b/src/pages/settings/settings.tsx
@@ -392,12 +392,14 @@ const FormSettings = () => {
   };
 
   const handleCancelConfirmationModal = () => {
-    setIsConfirmationModalVisible(false);
-    setIsConfirmClearVisible(false);
+    if (!isButtonLoading) {
+      setIsConfirmationModalVisible(false);
+      setIsConfirmClearVisible(false);
+    }
   };
 
   const onConfirmClear = () => {
-    setIsConfirmationModalVisible(false);
+    // setIsConfirmationModalVisible(false);
     setIsButtonLoading(true);
     indexedDB.deleteDatabase('NeDB');
     setTimeout(() => {
@@ -456,6 +458,7 @@ const FormSettings = () => {
             handleCancel={handleCancelConfirmationModal}
             handleOk={onConfirmClear}
             confirmationLoading={isButtonLoading}
+            closable={!isButtonLoading}
             footer={[
               <Button
                 key="submit"
@@ -534,7 +537,7 @@ const FormSettings = () => {
                           required: true,
                         },
                         {
-                          pattern: /CLEAR/,
+                          pattern: /^CLEAR$/,
                           message: 'Please enter CLEAR',
                         },
                       ]}

--- a/src/pages/wallet/wallet.tsx
+++ b/src/pages/wallet/wallet.tsx
@@ -64,6 +64,9 @@ function WalletPage() {
       case DefaultWalletConfigs.TestNetConfig.name:
         networkColor = 'error';
         break;
+      case DefaultWalletConfigs.TestNetCroeseid3.name:
+        networkColor = 'error';
+        break;
       default:
         networkColor = 'default';
     }


### PR DESCRIPTION
Resolving problems reflected by Internal QA:
1. Optimized wallet deletion flow with freezing UI during deletion & success popup after deletion
2. Fixed wallet address changes in confirmation popup during wallet deletion
3. Freezing UI during Storage Cleaning 
4. Add croeseid-3 label color in Wallet Page
<img width="1267" alt="螢幕截圖 2021-06-04 下午8 45 55" src="https://user-images.githubusercontent.com/74586409/120803229-e9d79f80-c575-11eb-85ae-e24145e8dc38.png">

<img width="1269" alt="螢幕截圖 2021-06-04 下午8 38 57" src="https://user-images.githubusercontent.com/74586409/120803127-cf9dc180-c575-11eb-8db2-e91731b3887e.png">
<img width="1259" alt="螢幕截圖 2021-06-04 下午8 40 26" src="https://user-images.githubusercontent.com/74586409/120803137-d3c9df00-c575-11eb-9f6f-0170437e0139.png">
