### PR TITLE
Adding zip target mac os

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,8 @@
       "entitlements": "./build/entitlements.mac.plist",
       "entitlementsInherit": "./build/entitlements.mac.plist",
       "target": [
-        "dmg"
+        "dmg",
+        "zip"
       ],
       "category": "public.app-category.utilities",
       "darkModeSupport": true

--- a/package.json
+++ b/package.json
@@ -120,7 +120,8 @@
       "entitlementsInherit": "./build/entitlements.mac.plist",
       "target": [
         "dmg",
-        "zip"
+        "zip",
+        "pkg"
       ],
       "category": "public.app-category.utilities",
       "darkModeSupport": true


### PR DESCRIPTION
- Auto updater requires a MacOS zip target: https://github.com/electron-userland/electron-builder/issues/2199

- It's also important to note that zip targets might not work directly for users because of [this issue ](https://github.com/electron-userland/electron-builder/issues/4299). The reason it's now added as an extra target is mostly that we want to test the auto-updater module.

- We will be waiting for the release of the new electron-builder that has the fix for https://github.com/electron-userland/electron-builder/issues/4299, note that it was closed just yesterday on the electron builder repo.
