### PR TITLE
[Phrase Export] (Fix: #578) Add capability to export phrase

### DIFF
--- a/src/components/PasswordForm/PasswordFormModal.tsx
+++ b/src/components/PasswordForm/PasswordFormModal.tsx
@@ -26,6 +26,9 @@ interface PasswordFormModalProps {
 
   isButtonLoading?: boolean;
 
+  // Will ask for password again even after password was validated before
+  repeatValidation?: boolean;
+
   // TODO: use secure-string
   onValidatePassword: (
     password: string,
@@ -54,6 +57,10 @@ const PasswordFormModal: React.FC<PasswordFormModalProps> = props => {
       return;
     }
     await props.onSuccess(appPassword!);
+    if (props.repeatValidation) {
+      setAppPassword('');
+      setDisplayComponent('form');
+    }
   };
   const onFormFinish = async (password: string) => {
     const result = await props.onValidatePassword(password);

--- a/src/index.less
+++ b/src/index.less
@@ -62,6 +62,19 @@
   }
 }
 
+.ant-carousel {
+  .slick-next {
+    &::before {
+      content: '';
+    }
+  }
+  .slick-prev {
+    &::before {
+      content: '';
+    }
+  }
+}
+
 body {
   margin: 0;
   font-weight: 500;

--- a/src/pages/settings/settings.less
+++ b/src/pages/settings/settings.less
@@ -53,17 +53,14 @@
 .export-recovery-phrase-modal {
   width: 600px !important;
   .recovery-phrase-slider {
-    display: flex !important;
-    align-items: center;
-    justify-content: center;
     width: 450px;
-    height: 120px;
     margin: auto;
     .page {
       > div {
         display: flex !important;
         align-items: center;
         justify-content: space-evenly;
+        height: 120px;
       }
       .phrase {
         width: 140px;

--- a/src/pages/settings/settings.less
+++ b/src/pages/settings/settings.less
@@ -49,3 +49,36 @@
     }
   }
 }
+
+.export-recovery-phrase-modal {
+  width: 600px !important;
+  .recovery-phrase-slider {
+    display: flex !important;
+    align-items: center;
+    justify-content: center;
+    width: 450px;
+    height: 120px;
+    margin: auto;
+    .page {
+      > div {
+        display: flex !important;
+        align-items: center;
+        justify-content: space-evenly;
+      }
+      .phrase {
+        width: 140px;
+        margin: 7px 14px;
+        padding: 7px;
+        text-align: center;
+        border-bottom: 2px solid rgba(128, 128, 128, 0.1);
+        span {
+          color: @font-color;
+          opacity: 0.5;
+        }
+      }
+    }
+    .slick-dots.slick-dots-bottom {
+      display: none !important;
+    }
+  }
+}

--- a/src/pages/settings/settings.less
+++ b/src/pages/settings/settings.less
@@ -52,6 +52,9 @@
 
 .export-recovery-phrase-modal {
   width: 600px !important;
+  .item {
+    margin: 20px 0;
+  }
   .recovery-phrase-slider {
     width: 450px;
     margin: auto;
@@ -60,7 +63,7 @@
         display: flex !important;
         align-items: center;
         justify-content: space-evenly;
-        height: 120px;
+        height: 60px;
       }
       .phrase {
         width: 140px;
@@ -76,6 +79,30 @@
     }
     .slick-dots.slick-dots-bottom {
       display: none !important;
+    }
+  }
+  .phrase-block-container {
+    display: grid;
+    grid-template-columns: 126px 126px 126px;
+    justify-content: center;
+    margin: auto;
+    column-gap: 28px;
+    row-gap: 7px;
+    .phrase-block {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 32px;
+      color: @azure;
+      font-size: 14px;
+      background-color: @light-azure;
+      border: 2px solid @azure;
+      border-radius: 4px;
+      cursor: pointer;
+      &.current {
+        color: #fff;
+        background-color: @azure;
+      }
     }
   }
 }

--- a/src/pages/settings/settings.tsx
+++ b/src/pages/settings/settings.tsx
@@ -380,7 +380,7 @@ function MetaInfoComponent() {
             <div className="title">Data Analytics</div>
             <div className="description">
               The data collected for analytics is used to prioritize development for new features
-              and functionalities and also to improve implemented features
+              and functionalities and also to improve implemented features.
             </div>
             <Switch
               checked={!defaultGAStateDisabled}
@@ -391,7 +391,7 @@ function MetaInfoComponent() {
           </div>
           <Divider />
           <div className="item">
-            <div className="title">Export your recovery phrase</div>
+            <div className="title">Export your Recovery Phrase</div>
             <div className="description">
               You are required to enter your App Password for this action.
             </div>

--- a/src/pages/settings/settings.tsx
+++ b/src/pages/settings/settings.tsx
@@ -197,11 +197,13 @@ function MetaInfoComponent() {
   const [isExportRecoveryPhraseModalVisible, setIsExportRecoveryPhraseModalVisible] = useState<
     boolean
   >(false);
+  const [currentSlide, setCurrentSlide] = useState(0);
 
   const didMountRef = useRef(false);
 
   // Slider related
   let recoveryPhraseSlider: CarouselRef | null = null;
+  const itemsPerPage = 3;
 
   const NextArrow = props => {
     const { className, style, onClick } = props;
@@ -246,8 +248,11 @@ function MetaInfoComponent() {
     prevArrow: <PrevArrow />,
     infinite: false,
     initialSlide: 0,
-    slidesPerRow: 3,
+    slidesPerRow: itemsPerPage,
     variableWidth: false,
+    beforeChange: (oldIndex, newIndex) => {
+      setCurrentSlide(newIndex);
+    },
   };
 
   const onCopyClick = () => {
@@ -479,13 +484,29 @@ function MetaInfoComponent() {
                     <div>
                       <div className="phrase">
                         <span>{index + 1}. </span>
-                        {item}{' '}
+                        {item}
                       </div>
                     </div>
                   </div>
                 );
               })}
             </Carousel>
+          </div>
+          <div className="item phrase-block-container">
+            {decryptedPhrase?.split(' ').map((item, index) => {
+              const isCurrent =
+                index >= currentSlide * itemsPerPage && index < (currentSlide + 1) * itemsPerPage;
+              return (
+                <div
+                  className={`phrase-block ${isCurrent ? 'current' : ''}`}
+                  onClick={() => {
+                    recoveryPhraseSlider?.goTo(Math.floor(index / Math.max(1, itemsPerPage)));
+                  }}
+                >
+                  {index + 1}
+                </div>
+              );
+            })}
           </div>
           <div className="item">
             <Alert

--- a/src/pages/settings/settings.tsx
+++ b/src/pages/settings/settings.tsx
@@ -391,6 +391,7 @@ function MetaInfoComponent() {
               You are required to enter your App Password for this action.
             </div>
             <Button
+              type="primary"
               onClick={() => {
                 showPasswordInput();
               }}
@@ -432,7 +433,7 @@ function MetaInfoComponent() {
         // confirmationLoading={isButtonLoading}
         // closable={!isButtonLoading}
         footer={[
-          <CopyToClipboard text={decryptedPhrase}>
+          <CopyToClipboard key="copy" text={decryptedPhrase}>
             <Button
               type="primary"
               onClick={() => {
@@ -451,8 +452,6 @@ function MetaInfoComponent() {
             }}
             // hidden={isConfirmClearVisible}
             // disabled={isButtonDisabled}
-
-            danger
           >
             Close
           </Button>,

--- a/src/variables.less
+++ b/src/variables.less
@@ -1,5 +1,6 @@
 // Theme Customization
 @azure: #1199fa;
+@light-azure: #f6fafe;
 @white: #fff;
 @green: #20bca4;
 @red: #f27474;


### PR DESCRIPTION
Added export button in `Settings` => `General Configuration`
<img width="584" alt="螢幕截圖 2021-07-15 下午8 42 36" src="https://user-images.githubusercontent.com/74586409/125789849-97538995-5b2e-44d4-aac2-53b274f2a5b7.png">

Password entry required
<img width="724" alt="螢幕截圖 2021-07-15 下午8 32 57" src="https://user-images.githubusercontent.com/74586409/125788695-1e4e79c8-aaac-49d0-92fe-42c53ea6e09d.png">

UIUX Referencing DeFi Wallet:
The choice of 3 items per page is the highest common factor of all possible total number of words in recovery phrase: `12,15,18,21,24`
<img width="1272" alt="螢幕截圖 2021-07-15 下午8 28 56" src="https://user-images.githubusercontent.com/74586409/125788515-4b1be0b7-ff64-47e4-9d88-955b036ab18b.png">

![Image from iOS](https://user-images.githubusercontent.com/74586409/125788830-049b97c3-8581-4853-8d14-45a09e213bb1.png)


