### PR TITLE
Avoid null selected asset in settings after re-creation of new static

### DIFF
--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -649,12 +649,6 @@ const HomePage = () => {
       const sessionData = await walletService.retrieveCurrentSession();
       const currentAsset = await walletService.retrieveDefaultWalletAsset(sessionData);
       const allAssets = await walletService.retrieveCurrentWalletAssets(sessionData);
-      await walletService.IBCAssetsFetch(sessionData);
-
-      // const allTransfers: TransferTransactionData[] = await walletService.retrieveAllTransfers(
-      //   sessionData.wallet.identifier,
-      //   currentAsset,
-      // );
 
       const allNftTransfer: NftAccountTransactionData[] = await walletService.getAllNFTAccountTxs(
         sessionData,
@@ -667,12 +661,6 @@ const HomePage = () => {
 
       setdefaultWalletAsset(currentAsset);
 
-      // const transferTabularData = convertTransfers(
-      //   allTransfers,
-      //   walletAllAssets,
-      //   sessionData,
-      //   currentAsset,
-      // );
       const nftTransferTabularData = convertNftTransfers(allNftTransfer);
 
       showWalletStateNotification(currentSession.wallet.config);

--- a/src/pages/settings/settings.tsx
+++ b/src/pages/settings/settings.tsx
@@ -631,7 +631,10 @@ const FormSettings = () => {
   let gasLimit = FIXED_DEFAULT_GAS_LIMIT;
 
   useEffect(() => {
-    setCurrentAssetIdentifier(session.activeAsset?.identifier);
+    const selectedIdentifier = walletAllAssets.find(
+      asset => asset.identifier === session.activeAsset?.identifier,
+    )?.identifier;
+    setCurrentAssetIdentifier(selectedIdentifier || walletAllAssets[0].identifier);
 
     if (defaultSettings.fee !== undefined) {
       networkFee = defaultSettings.fee.networkFee;

--- a/src/service/WalletService.ts
+++ b/src/service/WalletService.ts
@@ -1395,7 +1395,12 @@ class WalletService {
       const assetGeneration = walletOps.generate(wallet.config, wallet.identifier, phrase);
 
       await this.saveAssets(assetGeneration.initialAssets);
-      await this.syncAll(new Session(wallet));
+
+      const activeAsset = assetGeneration.initialAssets[0];
+      const newSession = new Session(wallet, activeAsset);
+      await this.setCurrentSession(newSession);
+
+      await this.syncAll(newSession);
     }
   }
 


### PR DESCRIPTION
Clean up active asset state after new static assets creation - Reduce slight lags on the home screen.