### PR TITLE
bugfix: Address Book

### DIFF
--- a/src/components/AddressBookInput/AddressBookInput.tsx
+++ b/src/components/AddressBookInput/AddressBookInput.tsx
@@ -55,6 +55,7 @@ const AddressBookInput = (props: IAddressBookInputProps) => {
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <AutoComplete
         showSearch
+        allowClear
         dropdownRender={menu => (
           <div>
             {menu}
@@ -84,7 +85,15 @@ const AddressBookInput = (props: IAddressBookInputProps) => {
             value: contact.address,
             label: (
               <>
-                <div>{contact.label}</div>
+                <div
+                  style={{
+                    overflow: 'hidden',
+                    whiteSpace: 'nowrap',
+                    textOverflow: 'ellipsis',
+                  }}
+                >
+                  {contact.label}
+                </div>
                 <div style={{ color: '#626973', fontSize: '12px' }}>{contact.address}</div>
               </>
             ),
@@ -136,10 +145,28 @@ const AddressBookInput = (props: IAddressBookInputProps) => {
             }}
             tagRender={() => {
               return (
-                <>
-                  <div style={{ float: 'left' }}>{currentContact.label}</div>
+                <div
+                  style={{
+                    maxWidth: '420px',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    overflow: 'hidden',
+                    alignItems: 'flex-start',
+                  }}
+                >
+                  <div
+                    style={{
+                      width: '100%',
+                      textAlign: 'left',
+                      overflow: 'hidden',
+                      whiteSpace: 'nowrap',
+                      textOverflow: 'ellipsis',
+                    }}
+                  >
+                    {currentContact.label}
+                  </div>
                   <div style={{ color: '#626973', fontSize: '12px' }}>{currentContact.address}</div>
-                </>
+                </div>
               );
             }}
           />

--- a/src/components/AddressBookModal/AddAddressModal.tsx
+++ b/src/components/AddressBookModal/AddAddressModal.tsx
@@ -48,21 +48,9 @@ const AddAddressModal = (props: IAddAddressModalProps) => {
 
   const [selectedNetworkValue, setSelectedNetworkValue] = useState<string>('');
   const [selectedAsset, setSelectedAsset] = useState<UserAsset>();
-
   const allAssets = useRecoilValue(walletAllAssetsState);
 
-  const customAddressValidator = useMemo(() => {
-    if (!selectedAsset) {
-      return null;
-    }
-    return TransactionUtils.addressValidator(currentSession, selectedAsset, AddressType.USER);
-  }, [selectedAsset]);
-
   const isEditing = !!contact;
-
-  const title = isEditing
-    ? t('settings.addressBook.editAddress')
-    : t('settings.addressBook.addAddress');
 
   const allAssetsFromNetwork = (networkValue: string) => {
     const network = SupportedNetworks.find(n => n.label === networkValue);
@@ -71,6 +59,30 @@ const AddAddressModal = (props: IAddAddressModalProps) => {
     }
     return allAssets.filter(asset => asset.assetType === network.networkType);
   };
+
+  React.useEffect(() => {
+    if (!isEditing || !contact) {
+      return;
+    }
+    const network = contact.chainName;
+    setSelectedNetworkValue(network);
+    const assetList = allAssetsFromNetwork(network);
+    const asset = assetList?.find(a => a.symbol === contact?.assetSymbol);
+    if (asset) {
+      setSelectedAsset(asset);
+    }
+  }, [isEditing]);
+
+  const customAddressValidator = useMemo(() => {
+    if (!selectedAsset) {
+      return null;
+    }
+    return TransactionUtils.addressValidator(currentSession, selectedAsset, AddressType.USER);
+  }, [selectedAsset]);
+
+  const title = isEditing
+    ? t('settings.addressBook.editAddress')
+    : t('settings.addressBook.addAddress');
 
   const assets = useMemo(() => {
     return allAssetsFromNetwork(selectedNetworkValue);
@@ -182,12 +194,12 @@ const AddAddressModal = (props: IAddAddressModalProps) => {
         </Form.Item>
         <Form.Item
           name={FormKeys.asset}
-          label={t('navbar.assets')}
+          label={t('settings.form1.assetIdentifier.label')}
           initialValue={contact?.assetSymbol}
           rules={[
             {
               required: true,
-              message: `${t('navbar.assets')} ${t('general.required')}`,
+              message: `${t('settings.form1.assetIdentifier.label')} ${t('general.required')}`,
             },
           ]}
         >

--- a/src/components/ConfirmModal/ConfirmModal.tsx
+++ b/src/components/ConfirmModal/ConfirmModal.tsx
@@ -18,14 +18,22 @@ const ConfirmModal = (props: IConfirmModalProps) => {
     <Modal
       visible={visible}
       onCancel={onCancel}
-      footer={[
-        <Button type="primary" onClick={onConfirm}>
-          {confirmText}
-        </Button>,
-        <Button type="link" onClick={onCancel}>
-          {t('general.cancel')}
-        </Button>,
-      ]}
+      footer={
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <Button type="primary" onClick={onConfirm}>
+            {confirmText}
+          </Button>
+          <Button type="link" onClick={onCancel}>
+            {t('general.cancel')}
+          </Button>
+        </div>
+      }
     >
       {children}
     </Modal>

--- a/src/pages/settings/tabs/AddressBook/AddressBook.tsx
+++ b/src/pages/settings/tabs/AddressBook/AddressBook.tsx
@@ -41,10 +41,12 @@ const AddressBook = () => {
   const AddressBookTableColumns = [
     {
       key: 'asset',
+      width: '70px',
       render: (contact: AddressBookContact) => <div>{contact.assetSymbol}</div>,
     },
     {
       key: 'network',
+      width: '180px',
       render: (contact: AddressBookContact) => {
         return (
           <Tag
@@ -58,15 +60,31 @@ const AddressBook = () => {
     },
     {
       key: 'address',
+      ellipsis: true,
       render: (contact: AddressBookContact) => (
-        <div>
-          <div style={{ fontWeight: 'bold', fontSize: '14px' }}>{contact.label}</div>
+        <div
+          style={{
+            overflow: 'hidden',
+          }}
+        >
+          <div
+            style={{
+              fontWeight: 'bold',
+              fontSize: '14px',
+              whiteSpace: 'nowrap',
+              textOverflow: 'ellipsis',
+              overflow: 'hidden',
+            }}
+          >
+            {contact.label}
+          </div>
           <div style={{ color: '#777777' }}>{contact.address}</div>
         </div>
       ),
     },
     {
       key: 'action',
+      width: '150px',
       render: (contact: AddressBookContact) => (
         <div style={{ display: 'flex' }}>
           <Space size="middle">


### PR DESCRIPTION
Close #822 

- [x] label auto shrink 
![image](https://user-images.githubusercontent.com/91446598/142106384-b14279b6-19f3-4468-9103-593a1ee546a1.png)
![image](https://user-images.githubusercontent.com/91446598/142122764-b9a759e0-5188-42ed-890f-5448ff62213c.png)
![image](https://user-images.githubusercontent.com/91446598/142122849-bdc3c6fe-1902-48c4-9964-394db0c54598.png)
- [x] Center buttons in Remove Address Modal
![image](https://user-images.githubusercontent.com/91446598/142128617-fe8d5cd2-5186-4b0b-b842-8e5969d8fc1d.png)
- [x] Address field is not validated when Edit any existing addresses (until a network is selected)
- [x] Assets item list is empty when Edit is clicked in any existing addresses, (until a network is selected)
- [x] Typo Assets. Should be Asset instead
