### PR TITLE
Problem: Support Crc20 token data

### DIFF
--- a/src/service/cronos/CronosClient.ts
+++ b/src/service/cronos/CronosClient.ts
@@ -4,12 +4,19 @@ import { EVMClient } from '../rpc/clients/EVMClient';
 import {
   ICronosChainIndexAPI,
   txListRequestOptions,
-  txPendingListRequestOptions,
+  queryPaginationOptions,
+  tokenTransfersRequestOptions,
 } from '../rpc/interface/cronos.chainIndex';
 import {
   TxListAPIResponse,
   txListByAccountRequestParams,
   PendingTxListAPIResponse,
+  ContractDataResponse,
+  tokenContractDataRequestParams,
+  TokenTransferEventLogsResponse,
+  tokenTransfersRequestParams,
+  tokensOwnedByAddressRequestParams,
+  TokensOwnedByAddressResponse,
 } from '../rpc/models/cronos.models';
 
 /**
@@ -63,7 +70,7 @@ export class CronosClient extends EVMClient implements ICronosChainIndexAPI {
 
   getPendingTxsByAddress = async (
     address: string,
-    options?: txPendingListRequestOptions,
+    options?: queryPaginationOptions,
   ): Promise<PendingTxListAPIResponse> => {
     const requestParams: txListByAccountRequestParams = {
       module: 'account',
@@ -83,4 +90,66 @@ export class CronosClient extends EVMClient implements ICronosChainIndexAPI {
     }
     return txListResponse.data;
   };
+
+  async getTokenTransfersByAddress(
+    address: string,
+    options?: tokenTransfersRequestOptions,
+  ): Promise<TokenTransferEventLogsResponse> {
+
+    const requestParams: tokenTransfersRequestParams = {
+      module: 'account',
+      action: 'tokentx',
+      address,
+      ...options,
+    };
+
+    const txListResponse: AxiosResponse<TokenTransferEventLogsResponse> = await axios({
+      baseURL: this.cronosExplorerAPIBaseURL,
+      url: '/api',
+      params: requestParams,
+    });
+
+    if (txListResponse.status !== 200) {
+      throw new Error('Could not fetch token transfers from Cronos Chain Index API.');
+    }
+    return txListResponse.data;
+  }
+
+  async getTokensOwnedByAddress(address: string): Promise<TokensOwnedByAddressResponse> {
+    const requestParams: tokensOwnedByAddressRequestParams = {
+      module: 'account',
+      action: 'tokenlist',
+      address,
+    };
+
+    const txListResponse: AxiosResponse<TokensOwnedByAddressResponse> = await axios({
+      baseURL: this.cronosExplorerAPIBaseURL,
+      url: '/api',
+      params: requestParams,
+    });
+
+    if (txListResponse.status !== 200) {
+      throw new Error('Could not fetch token owned by user address from Cronos Chain Index API.');
+    }
+    return txListResponse.data;
+  }
+
+  async getContractDataByAddress(contractAddress: string): Promise<ContractDataResponse> {
+    const requestParams: tokenContractDataRequestParams = {
+      module: 'token',
+      action: 'getToken',
+      contractaddress: contractAddress,
+    };
+
+    const txListResponse: AxiosResponse<ContractDataResponse> = await axios({
+      baseURL: this.cronosExplorerAPIBaseURL,
+      url: '/api',
+      params: requestParams,
+    });
+
+    if (txListResponse.status !== 200) {
+      throw new Error('Could not fetch token owned by user address from Cronos Chain Index API.');
+    }
+    return txListResponse.data;
+  }
 }

--- a/src/service/rpc/interface/cronos.chainIndex.ts
+++ b/src/service/rpc/interface/cronos.chainIndex.ts
@@ -1,8 +1,8 @@
-import { TxListAPIResponse, PendingTxListAPIResponse } from '../models/cronos.models';
+import { TxListAPIResponse, PendingTxListAPIResponse, TokenTransferEventLogsResponse, TokensOwnedByAddressResponse, ContractDataResponse } from '../models/cronos.models';
 
 // Reference: https://cronos.crypto.org/explorer/api-docs
 
-export interface txListRequestOptions extends txPendingListRequestOptions {
+export interface txListRequestOptions extends queryPaginationOptions {
   sort?: 'desc' | 'asc' | undefined;
   startblock?: number | undefined;
   endblock?: number | undefined;
@@ -11,7 +11,17 @@ export interface txListRequestOptions extends txPendingListRequestOptions {
   unixendtimestamp?: number | undefined;
 }
 
-export interface txPendingListRequestOptions {
+export interface tokenTransfersRequestOptions extends queryCommonOptions {
+  contractaddress?: string | undefined;
+}
+
+export interface queryCommonOptions extends queryPaginationOptions {
+  sort?: 'desc' | 'asc' | undefined;
+  startblock?: number | undefined;
+  endblock?: number | undefined;
+}
+
+export interface queryPaginationOptions {
   page?: string | undefined;
   offset?: string | undefined;
 }
@@ -21,11 +31,25 @@ export interface ICronosChainIndexAPI {
   getTxsByAddress(address: string, options?: txListRequestOptions): Promise<TxListAPIResponse>;
   getPendingTxsByAddress(
     address: string,
-    options?: txPendingListRequestOptions,
+    options?: queryPaginationOptions,
   ): Promise<PendingTxListAPIResponse>;
+
+  // - Token transfers event logs by address
+  //?module=account&action=tokentx&address={addressHash}
+  getTokenTransfersByAddress(
+    address: string,
+    options?: tokenTransfersRequestOptions,
+  ): Promise<TokenTransferEventLogsResponse>;
+
+  // Returns a list of tokens owned by an address
+  // ?module=account&action=tokenlist&address={addressHash}
+  getTokensOwnedByAddress(address: string): Promise<TokensOwnedByAddressResponse>;
+
+  // Get ERC-20 or ERC-721 token by contract address.
+  // ?module=token&action=getToken&contractaddress={contractAddressHash}
+  getContractDataByAddress(contractAddress: string): Promise<ContractDataResponse>;
 
   // Todo:
   // - Internal Transactions
-  // - Token transfers
   // - Multi-balance by Address
 }

--- a/src/service/rpc/models/cronos.models.ts
+++ b/src/service/rpc/models/cronos.models.ts
@@ -12,10 +12,89 @@ export interface PendingTxListAPIResponse extends ExplorerAPIResponse {
   result: PendingTransactionDetail[];
 }
 
-export interface txListByAccountRequestParams {
+export interface TokenTransferEventLogsResponse extends ExplorerAPIResponse {
+  result: TokenTransferEventLog[];
+}
+
+export interface TokensOwnedByAddressResponse extends ExplorerAPIResponse {
+  result: TokenDataOwnedByAddress[];
+}
+
+export interface ContractDataResponse extends ExplorerAPIResponse {
+  result: ContractData;
+}
+
+export interface txListByAccountRequestParams extends ApiRequestParamsBase {
   module: 'account';
   action: 'txlist' | 'pendingtxlist';
   address: string;
+}
+
+export interface tokenTransfersRequestParams extends ApiRequestParamsBase {
+  module: 'account';
+  action: 'tokentx';
+  address: string;
+}
+
+export interface tokensOwnedByAddressRequestParams extends ApiRequestParamsBase {
+  module: 'account';
+  action: 'tokenlist';
+  address: string;
+}
+
+export interface tokenContractDataRequestParams extends ApiRequestParamsBase {
+  module: 'token';
+  action: 'getToken';
+  contractaddress: string;
+}
+
+export interface ApiRequestParamsBase {
+  module: 'account' | 'token';
+  action: 'txlist' | 'pendingtxlist' | 'tokentx' | 'tokenlist' | 'getToken';
+}
+
+// Token transfer event log
+export interface TokenTransferEventLog {
+  value: string;
+  blockHash: string;
+  blockNumber: string;
+  confirmations: string;
+  contractAddress: string;
+  cumulativeGasUsed: string;
+  from: string;
+  gas: string;
+  gasPrice: string;
+  gasUsed: string;
+  hash: string;
+  input: string;
+  logIndex: string;
+  nonce: string;
+  timeStamp: string;
+  to: string;
+  tokenDecimal: string;
+  tokenName: string;
+  tokenSymbol: string;
+  transactionIndex: string;
+}
+
+// Tokens owned by an address
+export interface TokenDataOwnedByAddress {
+  balance: string;
+  contractAddress: string;
+  decimals: string;
+  name: string;
+  symbol: string;
+  type: string;
+}
+
+export interface ContractData {
+  cataloged: boolean;
+  contractAddress: string;
+  decimals: string;
+  name: string;
+  symbol: string;
+  totalSupply: string;
+  type: string;
 }
 
 export interface TransactionDetail {


### PR DESCRIPTION
Added new support to `CronosIndexingAPi`:

```
// - Token transfers event logs by address
  //?module=account&action=tokentx&address={addressHash}
  getTokenTransfersByAddress(
    address: string,
    options?: tokenTransfersRequestOptions,
  ): Promise<TokenTransferEventLogsResponse>;

  // Returns a list of tokens owned by an address
  // ?module=account&action=tokenlist&address={addressHash}
  getTokensOwnedByAddress(address: string): Promise<TokensOwnedByAddressResponse>;

  // Get ERC-20 or ERC-721 token by contract address.
  // ?module=token&action=getToken&contractaddress={contractAddressHash}
  getContractDataByAddress(contractAddress: string): Promise<ContractDataResponse>;
```