### PR TITLE
Problem: Add missing bridge history records for custom destination addresses

### DIFF
--- a/src/pages/bridge/components/BridgeTransactionHistory.tsx
+++ b/src/pages/bridge/components/BridgeTransactionHistory.tsx
@@ -10,6 +10,7 @@ import {
   bech32ToEVMAddress,
   middleEllipsis,
   getCronosAsset,
+  getCryptoOrgAsset,
   getAssetBySymbolAndChain,
 } from '../../../utils/utils';
 
@@ -31,6 +32,7 @@ const BridgeTransactionHistory = () => {
 
   // eslint-disable-next-line
   const cronosAsset = getCronosAsset(walletAllAssets);
+  const cryptoOrgAsset = getCryptoOrgAsset(walletAllAssets);
 
   const bridgeService = new BridgeService(walletService.storageService);
 
@@ -271,7 +273,7 @@ const BridgeTransactionHistory = () => {
   useEffect(() => {
     const fetchBridgeHistory = async () => {
       if (cronosAsset) {
-        await bridgeService.fetchAndSaveBridgeTxs(cronosAsset?.address!);
+        await bridgeService.fetchAndSaveBridgeTxs(cronosAsset?.address!, cryptoOrgAsset?.address!);
       }
       const transactionHistory = await bridgeService.retrieveCurrentWalletBridgeTransactions();
       const processedHistory = convertBridgeTransfers(transactionHistory);

--- a/src/service/bridge/BridgeService.ts
+++ b/src/service/bridge/BridgeService.ts
@@ -328,7 +328,7 @@ export class BridgeService {
     );
   };
 
-  public async fetchAndSaveBridgeTxs(evmAddress: string) {
+  public async fetchAndSaveBridgeTxs(evmAddress: string, tendermintAddress: string) {
     try {
       const currentSession = await this.storageService.retrieveCurrentSession();
       const defaultBridgeDirection = BridgeTransferDirection.CRYPTO_ORG_TO_CRONOS;
@@ -341,7 +341,7 @@ export class BridgeService {
         loadedBridgeConfig?.bridgeIndexingUrl || defaultBridgeConfig?.bridgeIndexingUrl!;
 
       const response = await axios.get<BridgeTransactionListResponse>(
-        `${bridgeIndexingUrl}/activities?cronosevmAddress=${evmAddress}&order=sourceBlockTime.desc`,
+        `${bridgeIndexingUrl}/activities?cronosevmAddress=${evmAddress}&cryptoorgchainAddress=${tendermintAddress}&order=sourceBlockTime.desc`,
       );
       const loadedBridgeTransactions = response.data.result;
 


### PR DESCRIPTION
## Problem
When transferring CRO from Crypto.org to my Cronos custom address, the bridge transfer record is not showing due to existing query on one single Cronos address, which is derived from the wallet key. 