### PR TITLE
Update CHANGELOG for v0.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 *Unreleased*
 
 *Released*
+## [v0.6.5] - 2022-01-19
+### Bug fixes
+- NFT transaction list sorted by time
+- Bridge transaction list sorted by time
+- Repeated records in NFT transaction list when switching page
+- Incorrect Explorer URL after settings update on Cronos Assets
+
 ## [v0.6.4] - 2022-01-13
 ### Additions
 - Tectonic Support


### PR DESCRIPTION
## [v0.6.5] - 2022-01-19
### Bug fixes
- NFT transaction list sorted by time
- Bridge transaction list sorted by time
- Repeated records in NFT transaction list when switching page
- Incorrect Explorer URL after settings update on Cronos Assets