### PR TITLE
Feat: Support EIP-712 & signPersonalMessage sign on Ledger devices

### DIFF
--- a/electron/IpcMain.ts
+++ b/electron/IpcMain.ts
@@ -142,5 +142,44 @@ export class IpcMain {
       }
       event.returnValue = ret;
     });
+    ipcMain.on('ethSignPersonalMessage', async (event: any, arg: any) => {
+      let ret = {};
+      console.log('ethSignPersonalMessage, ', arg.message, ' . ', arg.index);
+
+      try {
+        const sig = await this.ethProvider.signPersonalMessage(arg.message, arg.index);
+        ret = {
+          sig,
+          success: true,
+          label: 'ethSignPersonalMessage reply',
+        };
+      } catch (e) {
+        ret = {
+          success: false,
+          error: e.toString(),
+        };
+        console.error('ethSignPersonalMessage error ', e);
+      }
+
+      event.returnValue = ret;
+    });
+    ipcMain.on('ethSignTypedDataV4', async (event: any, arg: any) => {
+      let ret = {};
+      try {
+        const sig = await this.ethProvider.signTypedDataV4(arg.typedData, arg.index);
+        ret = {
+          sig,
+          success: true,
+          label: 'ethSignTypedDataV4 reply',
+        };
+      } catch (e) {
+        ret = {
+          success: false,
+          error: e.toString(),
+        };
+        console.error('ethSignTypedDataV4 error ' + e);
+      }
+      event.returnValue = ret;
+    });
   }
 }

--- a/src/pages/dapp/browser/DappBrowser.tsx
+++ b/src/pages/dapp/browser/DappBrowser.tsx
@@ -179,7 +179,7 @@ const DappBrowser = forwardRef<DappBrowserRef, DappBrowserProps>((props: DappBro
     ) => {
       setTxEvent(event);
       // prompt for password
-      if (!decryptedPhrase) {
+      if (!decryptedPhrase && !isLedgerWallet) {
         setInputPasswordVisible(true);
       } else {
         setRequestConfirmationVisible(true);
@@ -196,7 +196,7 @@ const DappBrowser = forwardRef<DappBrowserRef, DappBrowserProps>((props: DappBro
     ) => {
       setTxEvent(event);
       // prompt for password
-      if (!decryptedPhrase) {
+      if (!decryptedPhrase && !isLedgerWallet) {
         setInputPasswordVisible(true);
       } else {
         setRequestConfirmationVisible(true);
@@ -213,7 +213,7 @@ const DappBrowser = forwardRef<DappBrowserRef, DappBrowserProps>((props: DappBro
     ) => {
       setTxEvent(event);
       // prompt for password
-      if (!decryptedPhrase) {
+      if (!decryptedPhrase && !isLedgerWallet) {
         setInputPasswordVisible(true);
       } else {
         setRequestConfirmationVisible(true);

--- a/src/pages/dapp/browser/useIPCProvider.ts
+++ b/src/pages/dapp/browser/useIPCProvider.ts
@@ -3,12 +3,14 @@ import { TransactionConfig } from 'web3-eth';
 import { useRecoilValue } from 'recoil';
 import Web3 from 'web3';
 import { ethers } from 'ethers';
-import { signTypedData_v4 } from 'eth-sig-util';
 import { TransactionPrepareService } from '../../../service/TransactionPrepareService';
 import { walletService } from '../../../service/WalletService';
 import { ChainConfig } from './config';
 import { DappBrowserIPC } from '../types';
-import { evmTransactionSigner } from '../../../service/signers/EvmTransactionSigner';
+import {
+  evmTransactionSigner,
+  EvmTransactionSigner,
+} from '../../../service/signers/EvmTransactionSigner';
 import { EVMContractCallUnsigned } from '../../../service/signers/TransactionSupported';
 import { walletAllAssetsState } from '../../../recoil/atom';
 import { getCronosAsset } from '../../../utils/utils';
@@ -228,23 +230,24 @@ export const useIPCProvider = (props: IUseIPCProviderProps) => {
   );
 
   const handleSignMessage = useRefCallback(
-    async (eventId: number, data: string, passphrase: string, addPrefix: boolean) => {
-      const wallet = ethers.Wallet.fromMnemonic(passphrase);
-      if (addPrefix) {
-        const result = await wallet.signMessage(ethers.utils.arrayify(data));
-        sendResponse(eventId, result);
-      } else {
-        // deprecated
+    async (eventId: number, data: string, passphrase: string) => {
+      try {
+        const sig = await EvmTransactionSigner.signPersonalMessage(data, passphrase);
+        sendResponse(eventId, sig);
+      } catch (error) {
+        sendError(eventId, (error as any) as string);
       }
     },
   );
 
   const handleSignTypedMessage = useRefCallback(
     async (event: DappBrowserIPC.SignTypedMessageEvent, passphrase: string) => {
-      const wallet = ethers.Wallet.fromMnemonic(passphrase);
-      const bufferedKey = Buffer.from(wallet.privateKey.replace(/^(0x)/, ''), 'hex');
-      const sig = signTypedData_v4(bufferedKey, { data: JSON.parse(event.object.raw) });
-      sendResponse(event.id, sig);
+      try {
+        const sig = await EvmTransactionSigner.signTypedDataV4(event.object.raw, passphrase);
+        sendResponse(event.id, sig);
+      } catch (error) {
+        sendError(event.id, (error as any) as string);
+      }
     },
   );
 
@@ -330,8 +333,9 @@ export const useIPCProvider = (props: IUseIPCProviderProps) => {
         case 'signMessage':
           props.onRequestSignMessage(
             event,
-            passphrase => {
-              handleSignMessage.current(event.id, event.object.data, passphrase, false);
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            _ => {
+              sendError(event.id, 'Not implemented');
             },
             reason => {
               sendError(event.id, reason);
@@ -342,7 +346,7 @@ export const useIPCProvider = (props: IUseIPCProviderProps) => {
           props.onRequestSignPersonalMessage(
             event,
             passphrase => {
-              handleSignMessage.current(event.id, event.object.data, passphrase, true);
+              handleSignMessage.current(event.id, event.object.data, passphrase);
             },
             reason => {
               sendError(event.id, reason);

--- a/src/service/signers/IpcRender.ts
+++ b/src/service/signers/IpcRender.ts
@@ -1,4 +1,5 @@
 import { Bytes } from '@crypto-org-chain/chain-jslib/lib/dist/utils/bytes/bytes';
+import { hexToString } from 'web3-utils';
 import { ISignerProvider } from './SignerProvider';
 
 let electron: any;
@@ -126,5 +127,29 @@ export class IpcRender implements ISignerProvider {
       throw new Error(`test fail: ${arg.error}`);
     }
     return arg.address;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  public async signPersonalMessage(index: number, hexMessage: string): Promise<string> {
+    const message = hexToString(hexMessage);
+    const ret = electron.ipcRenderer.sendSync('ethSignPersonalMessage', {
+      message,
+      index,
+    });
+    if (!ret.success) {
+      throw new Error(`signPersonalMessage failed: ${ret.error}`);
+    }
+
+    return ret.sig;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  public async signTypedDataV4(index: number, typedData: string): Promise<string> {
+    const ret = electron.ipcRenderer.sendSync('ethSignTypedDataV4', { index, typedData });
+    if (!ret.success) {
+      throw new Error(`signTypedDataV4 failed: ${ret.error}`);
+    }
+
+    return ret.sig;
   }
 }

--- a/src/service/signers/LedgerWalletSignerProviderNative.ts
+++ b/src/service/signers/LedgerWalletSignerProviderNative.ts
@@ -60,4 +60,14 @@ export class LedgerWalletSignerProviderNative implements ISignerProvider {
     const address = await this.ipcRender.getEthAddress(index, display);
     return address;
   }
+
+  public async signTypedDataV4(index: number, typedData: string): Promise<string> {
+    const signature = await this.ipcRender.signTypedDataV4(index, typedData);
+    return signature;
+  }
+
+  public async signPersonalMessage(index: number, message: string): Promise<string> {
+    const signature = await this.ipcRender.signPersonalMessage(index, message);
+    return signature;
+  }
 }

--- a/src/service/signers/LedgerWalletSignerProviderWebusb.ts
+++ b/src/service/signers/LedgerWalletSignerProviderWebusb.ts
@@ -53,4 +53,14 @@ export class LedgerWalletSignerProviderWebusb implements ISignerProvider {
   public async getEthAddress(_index: number, _display: boolean): Promise<string> {
     return '';
   }
+
+  // eslint-disable-next-line  class-methods-use-this, @typescript-eslint/no-unused-vars
+  public async signPersonalMessage(index: number, message: string): Promise<string> {
+    throw new Error('not implemented');
+  }
+
+  // eslint-disable-next-line  class-methods-use-this, @typescript-eslint/no-unused-vars
+  public async signTypedDataV4(index: number, typedData: string): Promise<string> {
+    throw new Error('not implemented');
+  }
 }

--- a/src/service/signers/SignerProvider.ts
+++ b/src/service/signers/SignerProvider.ts
@@ -18,4 +18,6 @@ export interface ISignerProvider {
     data: string,
   ): Promise<string>;
   getEthAddress(index: number, display: boolean): Promise<string>;
+  signPersonalMessage(index: number, message: string): Promise<string>;
+  signTypedDataV4(index: number, typedData: string): Promise<string>;
 }

--- a/tests/src/test.ts
+++ b/tests/src/test.ts
@@ -226,6 +226,14 @@ export class LedgerWalletSignerProviderZemu implements ISignerProvider {
   public async getEthAddress(_index: number): Promise<string> {
     return '';
   }
+
+  async signPersonalMessage(_index: number, _message: string): Promise<string> {
+    return '';
+  }
+
+  async signTypedDataV4(_index: number, _typedData: string): Promise<string> {
+    return '';
+  }
 }
 
 async function main() {


### PR DESCRIPTION
Fix #973

This PR introduces the following sign methods implementations for Ledger devices,

- `eth_signTypedData`
- `eth_signTypedData_v4`
- `personal_sign`

VVS remove LP token approval uses ERC-712 sign to save gas, and it will fall back to normal transaction if the signing was not success, turns out we missed the signing part in the initial Ledger support on the DApp Browser.