### PR TITLE
feat: add file nesting support for VSCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,10 +25,10 @@ yarn-debug.log*
 yarn-error.log*
 
 .idea
-.vscode
 .eslintcache
 package-lock.json
 
 tinker/
 data/
 /debug.log
+

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,18 @@
+{
+  "i18n-ally.localesPaths": [
+    "src/language"
+  ],
+  "explorer.experimental.fileNesting.enabled": true,
+  "explorer.experimental.fileNesting.expand": false,
+  "explorer.experimental.fileNesting.patterns": {
+    ".gitignore": ".gitattributes, .gitmodules, .gitmessage, .mailmap, .git-blame*",
+    "*.js": "$(capture).js.map, $(capture).min.js, $(capture).d.ts",
+    "*.jsx": "$(capture).js",
+    "*.ts": "$(capture).js, $(capture).*.ts",
+    "*.tsx": "$(capture).ts",
+    ".env": "*.env, .env.*, env.d.ts",
+    "package.json": ".browserslist*, .circleci*, .codecov, .commitlint*, .editorconfig, .eslint*, .firebase*, .flowconfig, .github*, .gitlab*, .gitpod*, .huskyrc*, .jslint*, .lintstagedrc*, .markdownlint*, .mocha*, .node-version, .nodemon*, .npm*, .nvmrc, .pm2*, .pnp.*, .pnpm*, .prettier*, .releaserc*, .sentry*, .stackblitz*, .styleci*, .stylelint*, .tazerc*, .textlint*, .tool-versions, .travis*, .vscode*, .watchman*, .xo-config*, .yamllint*, .yarnrc*, api-extractor.json, apollo.config.*, appveyor*, ava.config.*, azure-pipelines*, bower.json, build.config.*, commitlint*, crowdin*, cypress.json, dangerfile*, dprint.json, firebase.json, grunt*, gulp*, jasmine.*, jenkins*, jest.config.*, jsconfig.*, karma*, lerna*, lint-staged*, nest-cli.*, netlify*, nodemon*, nx.*, package-lock.json, playwright.config.*, pm2.*, pnpm*, prettier*, pullapprove*, puppeteer.config.*, renovate*, rollup.config.*, stylelint*, tsconfig.*, tsdoc.*, tslint*, tsup.config.*, turbo*, typedoc*, vercel*, vetur.config.*, vitest.config.*, webpack.config.*, workspace.json, xo.config.*, yarn*, entitlements.mac.plist",
+    "readme.*": "authors, backers.md, changelog*, citation*, code_of_conduct.md, codeowners, contributing.md, contributors, copying, credits, governance.md, history.md, license*, maintainers, readme*, security.md, sponsors.md, content_management.md",
+    "vite.config.*": "*.env, .babelrc*, .codecov, .cssnanorc*, .env.*, .htmlnanorc*, .mocha*, .postcssrc*, .terserrc*, api-extractor.json, ava.config.*, babel.config.*, cssnano.config.*, cypress.json, env.d.ts, htmlnanorc.*, index.html, jasmine.*, jest.config.*, jsconfig.*, karma*, playwright.config.*, postcss.config.*, puppeteer.config.*, svgo.config.*, tailwind.config.*, tsconfig.*, tsdoc.*, unocss.config.*, vitest.config.*, webpack.config.*, windi.config.*",
+  },
+}

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@ledgerhq/hw-transport-webhid": "5.48.0",
     "@ledgerhq/hw-transport-webusb": "5.48.0",
     "@types/bluebird": "3.5.36",
+    "ansi-html": "0.0.8",
     "antd": "4.16.0",
     "axios": "0.21.2",
     "bech32": "2.0.0",
@@ -349,6 +350,7 @@
     "glob-parent": "6.0.2",
     "json-schema": "0.4.0",
     "follow-redirects": "1.14.7",
-    "simple-get": "4.0.1"
+    "simple-get": "4.0.1",
+    "ansi-html": "https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz"
   }
 }

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,9 +1,0 @@
-declare module '*.css';
-declare module '*.less';
-declare module '*.png';
-declare module '*.svg' {
-  import ReactComponent from 'react'
-  export function ReactComponent(props: React.SVGProps<SVGSVGElement>): React.ReactElement;
-  const url: string;
-  export default url;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4169,10 +4169,9 @@ ansi-escapes@^4.2.1, ansi-escapes@^4.3.0, ansi-escapes@^4.3.1:
   dependencies:
     type-fest "^0.21.3"
 
-ansi-html@0.0.7, ansi-html@^0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
-  integrity sha1-gTWEAhliqenm/QOflA0S9WynhZ4=
+ansi-html@0.0.7, ansi-html@0.0.8, ansi-html@^0.0.7, "ansi-html@https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz#69fbc4d6ccbe383f9736934ae34c3f8290f1bf41"
 
 ansi-regex@^2.0.0:
   version "2.1.1"


### PR DESCRIPTION
It's a newly supported feature on VSCode https://code.visualstudio.com/updates/v1_64#_explorer-file-nesting

We can get a cleaner file structure without actually moving files after setting it

<img width="282" alt="image" src="https://user-images.githubusercontent.com/91446598/157788410-192650cd-0403-4ec4-a6c1-76e4450731fa.png">
