### PR TITLE
Update package v0.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 *Unreleased*
 
 *Released*
+## [v0.7.4] - 2022-03-25
+### Additions
+- Duration selection for Auto Update disable
+### Bug fixes
+- Some CRC20 token price don't show properly
+- App crash when sending tokens with market price not available
+- Unable to withdraw Staking Rewards when validators > 10
+- Dead DApp list urls
+- Incorrect token settings during first time setup
 ## [v0.7.3] - 2022-03-22
 ### Additions
 - Tooltip for different Asset Types

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chain-desktop-wallet",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Crypto.com Chain Desktop Wallet App",
   "repository": "github:crypto-com/chain-desktop-wallet",
   "author": "Crypto.org <chain@crypto.org>",


### PR DESCRIPTION
## [v0.7.4] - 2022-03-25
### Additions
- Duration selection for Auto Update disable
### Bug fixes
- Some CRC20 token price don't show properly
- App crash when sending tokens with market price not available
- Unable to withdraw Staking Rewards when validators > 10
- Dead DApp list urls
- Incorrect token settings during first time setup