### PR TITLE
Fix: Enforce all transactions enter password again, except DApp browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -364,6 +364,8 @@
     "ansi-html": "https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
     "ansi-regex": "4.1.1",
     "ejs": "3.1.7",
-    "eventsource": "2.0.2"
+    "eventsource": "2.0.2",
+    "nth-check": "2.0.1",
+    "semver-regex": "3.1.3"
   }
 }

--- a/src/components/PasswordForm/PasswordFormModal.tsx
+++ b/src/components/PasswordForm/PasswordFormModal.tsx
@@ -28,7 +28,7 @@ export interface PasswordFormModalProps {
   isButtonLoading?: boolean;
 
   // Will ask for password again even after password was validated before
-  repeatValidation?: boolean;
+  skipRepeatValidation?: boolean;
 
   mask?: boolean;
 
@@ -109,7 +109,7 @@ const PasswordFormWithResult = (props: {
   successButtonText?: string;
   confirmPassword?: boolean;
   okButtonText?: string;
-  repeatValidation?: boolean;
+  skipRepeatValidation?: boolean;
   isButtonLoading?: boolean;
   successText: string;
 }) => {
@@ -168,9 +168,11 @@ const PasswordFormWithResult = (props: {
           return;
         }
         await props.onSuccess(appPassword!);
-        if (props.repeatValidation) {
-          setAppPassword('');
-          setDisplayComponent('form');
+        if (!props.skipRepeatValidation) {
+          setTimeout(() => {
+            setAppPassword('');
+            setDisplayComponent('form');
+          }, 200);
         }
       }}
     />

--- a/src/components/PasswordForm/SessionLockModal.tsx
+++ b/src/components/PasswordForm/SessionLockModal.tsx
@@ -10,7 +10,6 @@ const SessionLockModal = props => {
     onValidatePassword,
     onSuccess,
     onCancel,
-    repeatValidation,
   } = props;
   return PasswordFormModal({
     title,
@@ -21,7 +20,6 @@ const SessionLockModal = props => {
     onValidatePassword,
     onSuccess,
     onCancel,
-    repeatValidation,
     mask: true,
     maskStyle: {
       backdropFilter: 'blur(5px)',

--- a/src/layouts/home/home.tsx
+++ b/src/layouts/home/home.tsx
@@ -895,8 +895,6 @@ function HomeLayout(props: HomeLayoutProps) {
         title={t('general.passwordFormModal.title')}
         visible={inputPasswordVisible}
         successButtonText={t('general.continue')}
-        confirmPassword={false}
-        repeatValidation
       />
 
       <SessionLockModal
@@ -965,8 +963,6 @@ function HomeLayout(props: HomeLayoutProps) {
         title={t('general.sessionLockModal.title')}
         visible={isSessionLockModalVisible}
         successButtonText={t('general.continue')}
-        confirmPassword={false}
-        repeatValidation
       />
 
       <Layout>

--- a/src/pages/assets/components/FormSend.tsx
+++ b/src/pages/assets/components/FormSend.tsx
@@ -127,7 +127,8 @@ const FormSend: React.FC<FormSendProps> = props => {
   };
 
   const showPasswordInput = () => {
-    if (decryptedPhrase || currentSession.wallet.walletType === LEDGER_WALLET_TYPE) {
+    // TODO: check if decryptedPhrase expired
+    if ((decryptedPhrase && false) || currentSession.wallet.walletType === LEDGER_WALLET_TYPE) {
       if (!isLedgerConnected && currentSession.wallet.walletType === LEDGER_WALLET_TYPE) {
         ledgerNotification(currentSession.wallet, walletAsset!);
       }
@@ -442,7 +443,6 @@ const FormSend: React.FC<FormSendProps> = props => {
           title={t('general.passwordFormModal.title')}
           visible={inputPasswordVisible}
           successButtonText={t('general.continue')}
-          confirmPassword={false}
         />
 
         <SuccessModalPopup

--- a/src/pages/bridge/bridge.tsx
+++ b/src/pages/bridge/bridge.tsx
@@ -231,7 +231,8 @@ const CronosBridge = props => {
       ...form.getFieldsValue(),
     });
 
-    if (decryptedPhrase || session.wallet.walletType === LEDGER_WALLET_TYPE) {
+    // TODO: check if decryptedPhrase expired
+    if ((decryptedPhrase && false) || session.wallet.walletType === LEDGER_WALLET_TYPE) {
       const { tendermintAddress, evmAddress } = formValues;
       const { toAddress, isCustomToAddress } = form.getFieldsValue();
       let amount = form.getFieldValue('amount');

--- a/src/pages/dapp/browser/DappBrowser.tsx
+++ b/src/pages/dapp/browser/DappBrowser.tsx
@@ -327,7 +327,7 @@ const DappBrowser = forwardRef<DappBrowserRef, DappBrowserProps>((props: DappBro
           title={t('general.passwordFormModal.title')}
           visible
           successButtonText={t('general.continue')}
-          confirmPassword={false}
+          skipRepeatValidation
         />
       )}
       {txEvent && requestConfirmationVisible && (

--- a/src/pages/governance/governance.tsx
+++ b/src/pages/governance/governance.tsx
@@ -109,7 +109,8 @@ const GovernancePage = () => {
   };
 
   const showPasswordInput = () => {
-    if (decryptedPhrase || currentSession.wallet.walletType === LEDGER_WALLET_TYPE) {
+    // TODO: check if decryptedPhrase expired
+    if ((decryptedPhrase && false) || currentSession.wallet.walletType === LEDGER_WALLET_TYPE) {
       if (!isLedgerConnected && currentSession.wallet.walletType === LEDGER_WALLET_TYPE) {
         ledgerNotification(currentSession.wallet, userAsset!);
       }

--- a/src/pages/nft/nft.tsx
+++ b/src/pages/nft/nft.tsx
@@ -247,7 +247,8 @@ const FormMintNft = () => {
   };
 
   const showPasswordInput = () => {
-    if (decryptedPhrase || currentSession.wallet.walletType === LEDGER_WALLET_TYPE) {
+    // TODO: check if decryptedPhrase expired
+    if ((decryptedPhrase && false) || currentSession.wallet.walletType === LEDGER_WALLET_TYPE) {
       if (!isLedgerConnected && currentSession.wallet.walletType === LEDGER_WALLET_TYPE) {
         ledgerNotification(currentSession.wallet, walletAsset!);
       }
@@ -842,7 +843,6 @@ const FormMintNft = () => {
         title={t('general.passwordFormModal.title')}
         visible={inputPasswordVisible}
         successButtonText={t('general.continue')}
-        confirmPassword={false}
       />
       <SuccessModalPopup
         isModalVisible={isSuccessModalVisible}
@@ -1020,7 +1020,8 @@ const NftPage = () => {
   };
 
   const showPasswordInput = () => {
-    if (decryptedPhrase || currentSession.wallet.walletType === LEDGER_WALLET_TYPE) {
+    // TODO: check if decryptedPhrase expired
+    if ((decryptedPhrase && false) || currentSession.wallet.walletType === LEDGER_WALLET_TYPE) {
       if (!isLedgerConnected && currentSession.wallet.walletType === LEDGER_WALLET_TYPE) {
         ledgerNotification(currentSession.wallet, walletAsset!);
       }
@@ -1886,7 +1887,6 @@ const NftPage = () => {
                 title={t('general.passwordFormModal.title')}
                 visible={inputPasswordVisible}
                 successButtonText={t('general.continue')}
-                confirmPassword={false}
               />
               <SuccessModalPopup
                 isModalVisible={isSuccessModalVisible}

--- a/src/pages/restore/restore.tsx
+++ b/src/pages/restore/restore.tsx
@@ -456,7 +456,6 @@ const FormRestore: React.FC<FormRestoreProps> = props => {
         title={t('general.passwordFormModal.title')}
         visible={inputPasswordVisible}
         successButtonText={t('general.passwordFormModal.restoreWallet.successButton')}
-        confirmPassword={false}
       />
       <ErrorModalPopup
         isModalVisible={isErrorModalVisible}

--- a/src/pages/settings/components/MetaInfoComponent.tsx
+++ b/src/pages/settings/components/MetaInfoComponent.tsx
@@ -440,8 +440,6 @@ export function MetaInfoComponent() {
         title={t('general.passwordFormModal.title')}
         visible={inputPasswordVisible}
         successButtonText={t('general.continue')}
-        confirmPassword={false}
-        repeatValidation
       />
       <ModalPopup
         className="export-recovery-phrase-modal"

--- a/src/pages/staking/components/FormDelegationOperations.tsx
+++ b/src/pages/staking/components/FormDelegationOperations.tsx
@@ -132,7 +132,8 @@ export const FormDelegationOperations = props => {
   };
 
   const showPasswordInput = () => {
-    if (decryptedPhrase || currentSession.wallet.walletType === LEDGER_WALLET_TYPE) {
+    // TODO: check if decryptedPhrase expired
+    if ((decryptedPhrase && false) || currentSession.wallet.walletType === LEDGER_WALLET_TYPE) {
       if (!isLedgerConnected && currentSession.wallet.walletType === LEDGER_WALLET_TYPE) {
         ledgerNotification(currentSession.wallet, userAsset!);
       }
@@ -408,7 +409,6 @@ export const FormDelegationOperations = props => {
           title={t('general.passwordFormModal.title')}
           visible={inputPasswordVisible}
           successButtonText={t('general.continue')}
-          confirmPassword={false}
         />
 
         <SuccessModalPopup

--- a/src/pages/staking/components/FormDelegationRequest.tsx
+++ b/src/pages/staking/components/FormDelegationRequest.tsx
@@ -143,7 +143,8 @@ export const FormDelegationRequest = props => {
   };
 
   const showPasswordInput = () => {
-    if (decryptedPhrase || currentSession.wallet.walletType === LEDGER_WALLET_TYPE) {
+    // TODO: check if decryptedPhrase expired
+    if ((decryptedPhrase && false) || currentSession.wallet.walletType === LEDGER_WALLET_TYPE) {
       if (!isLedgerConnected && currentSession.wallet.walletType === LEDGER_WALLET_TYPE) {
         ledgerNotification(currentSession.wallet, walletAsset!);
       }
@@ -465,7 +466,6 @@ export const FormDelegationRequest = props => {
           title={t('general.passwordFormModal.title')}
           visible={inputPasswordVisible}
           successButtonText={t('general.continue')}
-          confirmPassword={false}
         />
         <SuccessModalPopup
           isModalVisible={isSuccessTransferModalVisible}

--- a/src/pages/staking/components/FormWithdrawStakingReward.tsx
+++ b/src/pages/staking/components/FormWithdrawStakingReward.tsx
@@ -164,7 +164,8 @@ export const FormWithdrawStakingReward = () => {
   };
 
   const showPasswordInput = (action: string) => {
-    if (decryptedPhrase || currentSession.wallet.walletType === LEDGER_WALLET_TYPE) {
+    // TODO: check if decryptedPhrase expired
+    if ((decryptedPhrase && false) || currentSession.wallet.walletType === LEDGER_WALLET_TYPE) {
       if (!isLedgerConnected && currentSession.wallet.walletType === LEDGER_WALLET_TYPE) {
         ledgerNotification(currentSession.wallet, walletAsset!);
         return;
@@ -528,7 +529,6 @@ export const FormWithdrawStakingReward = () => {
                 rewards && rewards.length > 3 ? 'address-container scrollable' : 'address-container'
               }
             >
-
               {rewards.map((elem, idx) => (
                 <>
                   <div
@@ -663,7 +663,6 @@ export const FormWithdrawStakingReward = () => {
         title={t('general.passwordFormModal.title')}
         visible={inputPasswordVisible}
         successButtonText={t('general.continue')}
-        confirmPassword={false}
       />
       <SuccessModalPopup
         isModalVisible={isSuccessTransferModalVisible}


### PR DESCRIPTION
## Background
Reported by Security Team, they'd like us to enforce password entry in any sort of scenarios. They've agreed that we may exclude this enforcement on DApp browser related transactions. 