### PR TITLE
Feature: Add default config button

### DIFF
--- a/src/config/StaticConfig.ts
+++ b/src/config/StaticConfig.ts
@@ -364,7 +364,7 @@ const TestnetCroeseid4: Network = {
   rpcUrl: 'https://testnet-croeseid-4.crypto.org:26657',
 };
 
-const TestNetCroeseid4Config: WalletConfig = {
+export const TestNetCroeseid4Config: WalletConfig = {
   enabled: true,
   name: NetworkName.TESTNET,
   derivationPath: 'm/44\'/1\'/0\'/0/0',
@@ -387,7 +387,7 @@ const TestNetCroeseid4Config: WalletConfig = {
   },
 };
 
-const MainNetConfig: WalletConfig = {
+export const MainNetConfig: WalletConfig = {
   enabled: true,
   name: NetworkName.MAINNET,
   derivationPath: 'm/44\'/394\'/0\'/0/0',

--- a/src/pages/settings/components/GeneralSettingsForm.tsx
+++ b/src/pages/settings/components/GeneralSettingsForm.tsx
@@ -12,6 +12,7 @@ import { EnableGeneralSettingsPropagation } from '../../../models/Wallet';
 import { AnalyticsService } from '../../../service/analytics/AnalyticsService';
 import { getChainName } from '../../../utils/utils';
 import { AssetIcon } from '../../../components/AssetIcon';
+import { UserAssetType } from '../../../models/UserAsset';
 
 const { Option } = Select;
 
@@ -31,7 +32,17 @@ export const GeneralSettingsForm = props => {
   const configurableAssets = useMemo(() => {
     return walletAllAssets.filter(asset => {
       return _.size(asset.contractAddress) < 1;
-    });
+    })
+      // Prioritize CRO assets over other assets
+      .sort((a, b) => {
+        if(a.mainnetSymbol === 'CRO') {
+          if(b.mainnetSymbol === 'CRO' && b.assetType === UserAssetType.TENDERMINT) {
+            return 1;
+          }
+          return -1;
+        }
+        return 1;
+      });
   }, [walletAllAssets]);
 
   const onSwitchAsset = value => {

--- a/src/pages/settings/settings.less
+++ b/src/pages/settings/settings.less
@@ -1,7 +1,11 @@
 .settings-content {
   padding: 24px;
   .container {
-    max-width: 500px;
+    max-width: 600px;
+    // width: 500px;
+    // .ant-row.ant-form-item.button {
+    //    width: 600px;
+    // }
     .item {
       margin-bottom: 20px;
     }


### PR DESCRIPTION
## Background
Adding Default Settings for Asset configs sounds useful as we have more static assets added now. We have it for bridge transfer config but not for Asset configs.

## Screenshot
<img width="660" alt="settings" src="https://user-images.githubusercontent.com/74586409/183879902-1d1f529e-9cd2-49e8-b393-3c28b2a8941e.png">
<img width="332" alt="123" src="https://user-images.githubusercontent.com/74586409/183881880-40c4ae74-c682-44c5-b25c-4fbf0fbeea5f.png">

