### PR TITLE
Problem: Single bad actor operating multiple nodes

### DIFF
--- a/config/app.moderation.json
+++ b/config/app.moderation.json
@@ -10,7 +10,12 @@
             "suspicious": [
                 "crocncl1xxuf6tsfsqm2zd2ype656dyr73x4fsjgd6m9en",
                 "crocncl1av95h6se2ptx0lsqkhwdy7u6eac2xusxrldl9d",
-                "crocncl1t3kju2j60k24kxgqx5q6vgm8ea6dn60jvgx972"
+                "crocncl1t3kju2j60k24kxgqx5q6vgm8ea6dn60jvgx972",
+                "crocncl1mgv55sy224en5yp4f2jh080ttm9n8eyqpdljfy",
+                "crocncl1zhyx4hmrzx574tmju7cvq0kwursdyc98su3dkv",
+                "crocncl1zxpt83udtxrq5sqgdcswv8vy3etk7m87zvd67a",
+                "crocncl1jvnpmn53wp5440e62v6ljnu5lyvf2vgaqcskce",
+                "crocncl1ggum4t06qpqlcfa0z2hrauftevqjf0h7tjvhtc"
             ]
         }
     }


### PR DESCRIPTION
The nodes in the PR are all confirmed to be operated by a single entity and has used them to purposefully decommission and then immediately recommissioning the nodes multiple times, causing whoever is at the lowest in the validator set to have a significant hit in uptime whenever the node joins or leaves the active set.

Most of the active validators are in agreement that this should not continue and therefore, request that these validator address be blacklisted