### PR TITLE
Temporarily skip Windows release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,10 +41,10 @@ jobs:
           # Log in to Snap Store
           snapcraft_token: ${{ secrets.snapcraft_token }}
 
-      - name: Install AzureSignTool
-        # Only install Azure Sign Tool on Windows
-        if: startsWith(matrix.os, 'windows')
-        run: dotnet tool install --global AzureSignTool
+      # - name: Install AzureSignTool
+      #   # Only install Azure Sign Tool on Windows
+      #   if: startsWith(matrix.os, 'windows')
+      #   run: dotnet tool install --global AzureSignTool
 
       - name: Extract current branch name
         shell: bash
@@ -96,43 +96,43 @@ jobs:
           API_KEY_ID: ${{ secrets.mac_api_key_id }}
           API_KEY_ISSUER_ID: ${{ secrets.mac_api_key_issuer_id }}
           
-      - name: Build Electron app (Windows)
-        if: startsWith(matrix.os, 'windows')
-        run: |
-          yarn run electron:build
+      # - name: Build Electron app (Windows)
+      #   if: startsWith(matrix.os, 'windows')
+      #   run: |
+      #     yarn run electron:build
 
-      - name: Sign built binary (Windows)
-        if: startsWith(matrix.os, 'windows')
-        # Instead of pointing to a specific .exe, uses a PowerShell script which iterates through all the files stored in dist folder. 
-        # If the file has the .exe extension, then it will use the AzureSignTool command to sign it.
-        run: |
-              cd dist; Get-ChildItem -recurse -Include **.exe | ForEach-Object {
-              $exePath = $_.FullName
-              & AzureSignTool sign -kvu "${{ secrets.azure_key_vault_url }}" -kvi "${{ secrets.azure_key_vault_client_id }}" -kvt "${{ secrets.azure_key_vault_tenant_id }}" -kvs "${{ secrets.azure_key_vault_client_secret }}" -kvc "${{ secrets.azure_key_vault_name }}" -tr http://timestamp.digicert.com -v $exePath
-              }; cd ..
+      # - name: Sign built binary (Windows)
+      #   if: startsWith(matrix.os, 'windows')
+      #   # Instead of pointing to a specific .exe, uses a PowerShell script which iterates through all the files stored in dist folder. 
+      #   # If the file has the .exe extension, then it will use the AzureSignTool command to sign it.
+      #   run: |
+      #         cd dist; Get-ChildItem -recurse -Include **.exe | ForEach-Object {
+      #         $exePath = $_.FullName
+      #         & AzureSignTool sign -kvu "${{ secrets.azure_key_vault_url }}" -kvi "${{ secrets.azure_key_vault_client_id }}" -kvt "${{ secrets.azure_key_vault_tenant_id }}" -kvs "${{ secrets.azure_key_vault_client_secret }}" -kvc "${{ secrets.azure_key_vault_name }}" -tr http://timestamp.digicert.com -v $exePath
+      #         }; cd ..
 
-      - name: Cleanup artifacts (Windows)
-        if: startsWith(matrix.os, 'windows')
-        run: |
-          mkdir dist/temp; Move-Item -Path dist/*.exe, dist/*.blockmap, dist/latest.yml -Destination dist/temp
-          npx rimraf "dist/!(temp)"
-          npx rimraf "dist/.icon-ico"
-          mv dist/temp/* dist
-          npx rimraf "dist/temp"
+      # - name: Cleanup artifacts (Windows)
+      #   if: startsWith(matrix.os, 'windows')
+      #   run: |
+      #     mkdir dist/temp; Move-Item -Path dist/*.exe, dist/*.blockmap, dist/latest.yml -Destination dist/temp
+      #     npx rimraf "dist/!(temp)"
+      #     npx rimraf "dist/.icon-ico"
+      #     mv dist/temp/* dist
+      #     npx rimraf "dist/temp"
 
-      - name: Upload artifacts (Windows)
-        uses: actions/upload-artifact@v2
-        if: startsWith(matrix.os, 'windows')
-        with:
-          name: ${{ matrix.os }}
-          path: dist
+      # - name: Upload artifacts (Windows)
+      #   uses: actions/upload-artifact@v2
+      #   if: startsWith(matrix.os, 'windows')
+      #   with:
+      #     name: ${{ matrix.os }}
+      #     path: dist
 
-      - name: Release Electron app (Windows)
-        uses: softprops/action-gh-release@v1
-        if: startsWith(matrix.os, 'windows')
-        with:
-          draft: true
-          tag_name: v${{ steps.package_json.outputs.version }}
-          files: "dist/**"
-        env:
-          GITHUB_TOKEN: ${{ secrets.github_token }}
+      # - name: Release Electron app (Windows)
+      #   uses: softprops/action-gh-release@v1
+      #   if: startsWith(matrix.os, 'windows')
+      #   with:
+      #     draft: true
+      #     tag_name: v${{ steps.package_json.outputs.version }}
+      #     files: "dist/**"
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.github_token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 *Unreleased*
 
 *Released*
-## [v1.3.0] - 2022-08-05
+## [v1.3.0] - 2022-08-24
 ### Additions
 - Ethereum Chain Support
 - Cosmos Hub ATOM Support


### PR DESCRIPTION
## Background
Release v.1.3.0 on Mac & Linux. Skip Windows release before the Azure signing certificate is ready. 