### PR TITLE
Problem: Fix non-hex message signing through walletConnect

### DIFF
--- a/src/service/walletconnect/useWalletConnect.ts
+++ b/src/service/walletconnect/useWalletConnect.ts
@@ -2,7 +2,7 @@ import WalletConnect from '@walletconnect/client';
 import { IJsonRpcRequest } from '@walletconnect/types';
 import { useCallback, useState } from 'react';
 import { useRecoilState } from 'recoil';
-import { hexToNumber } from 'web3-utils';
+import { hexToNumber, isHex, utf8ToHex } from 'web3-utils';
 import { EVM_MINIMUM_GAS_PRICE } from '../../config/StaticConfig';
 import { useRefCallback } from '../../hooks/useRefCallback';
 import { EVMChainConfig } from '../../models/Chain';
@@ -240,6 +240,9 @@ export const useWalletConnect = () => {
         if (error) {
           throw error;
         }
+        if(!isHex(payload.params[0])) {
+          payload.params[0] = utf8ToHex(payload.params[0]);
+        }
         log('SESSION_REQUEST', payload.params);
         const { peerMeta } = payload.params[0];
         setState({
@@ -260,6 +263,9 @@ export const useWalletConnect = () => {
       });
 
       connector.on('call_request', async (error, payload: IJsonRpcRequest) => {
+        if(!isHex(payload.params[0])) {
+          payload.params[0] = utf8ToHex(payload.params[0]);
+        }
         handleCallRequest.current(error, payload);
       });
 


### PR DESCRIPTION
## Issue
Message signing should often comes in Hex
<img width="604" alt="螢幕截圖 2022-11-03 下午5 43 01" src="https://user-images.githubusercontent.com/74586409/199701164-dde8309b-677c-4634-b3d4-cfa108510ddd.png">
But for some scenario, when a non-Hex string pass to WalletConnect, spaces got trimmed: 
<img width="431" alt="image (2)" src="https://user-images.githubusercontent.com/74586409/199701173-793ea350-86be-405f-9242-aa67e3d81427.png">
<img width="1392" alt="image" src="https://user-images.githubusercontent.com/74586409/199701188-b1ed2951-3d96-42c0-ac1d-66451a407be1.png">

Tracing back to the source, it's the `WalletConnect` Class from lib `@walletconnect` causing the issue. 