### PR TITLE
Fix: Ledger Address Mismatch & Balance goes to Zero after Wallet lock

### DIFF
--- a/src/layouts/home/home.tsx
+++ b/src/layouts/home/home.tsx
@@ -817,7 +817,7 @@ function HomeLayout(props: HomeLayoutProps) {
           await generalConfigService.setIsAppLockedByUser(false);
           setIsSessionLockModalVisible(false);
         }}
-        onSuccess={async password => {
+        onSuccess={async () => {
           await generalConfigService.setIsAppLockedByUser(false);
           notification.info({
             message: t('general.sessionLockModal.notification.message2'),
@@ -826,7 +826,6 @@ function HomeLayout(props: HomeLayoutProps) {
             placement: 'topRight',
           });
           setIsSessionLockModalVisible(false);
-          onWalletDecryptFinishCreateFreshAssets(password);
         }}
         onValidatePassword={async (password: string) => {
           const isValid = await secretStoreService.checkIfPasswordIsValid(password);


### PR DESCRIPTION
## Issue 
This issue was due to the fact that after every unlock wallet, it will runs `onWalletDecryptFinishCreateFreshAssets()` which remigrates all assets once again. But this step is not necessary at all. This step also lead to empty Ledger addresses.
- #1269
- #1271 
