### PR TITLE
feat: clear webview cache in Dapp browser

### DIFF
--- a/src/language/en-US.json
+++ b/src/language/en-US.json
@@ -490,6 +490,7 @@
   "dapp.chainConfig.reset": "Reset",
   "dapp.chainConfig.resetSuccessfully": "Reset successfully",
   "dapp.chainConfig": "Chain Config",
+  "dapp.clearCache": "Clear Webview Cache",
   "Wants to Add A Network": "Wants to Add A Network",
   "Approve": "Approve",
   "Wants to Switch Network": "Wants to Switch Network",

--- a/src/language/ko-KR.json
+++ b/src/language/ko-KR.json
@@ -488,6 +488,7 @@
   "dapp.chainConfig.reset": "repossess",
   "dapp.chainConfig.resetSuccessfully": "초기화",
   "dapp.chainConfig": "체인 구성",
+  "dapp.clearCache": "Clear WebView 캐시",
   "Wants to Add A Network": "블록 체인 네트워크를 추가하고 싶습니다",
   "Approve": "허용하다",
   "Wants to Switch Network": "블록 체인 네트워크를 전환하고 싶습니다",

--- a/src/language/zh-CN.json
+++ b/src/language/zh-CN.json
@@ -490,6 +490,7 @@
   "dapp.chainConfig.reset": "重置",
   "dapp.chainConfig.resetSuccessfully": "重置成功",
   "dapp.chainConfig": "链配置",
+  "dapp.clearCache": "清除 Webview 缓存",
   "Wants to Add A Network": "想要添加一条区块链网络",
   "Approve": "允许",
   "Wants to Switch Network": "想要切换区块链网络",

--- a/src/language/zh-HK.json
+++ b/src/language/zh-HK.json
@@ -490,6 +490,7 @@
   "dapp.chainConfig.reset": "重置",
   "dapp.chainConfig.resetSuccessfully": "重置成功",
   "dapp.chainConfig": "鏈配置",
+  "dapp.clearCache": "清除 Webview 緩存",
   "Wants to Add A Network": "想要添加一條區塊鍊網絡",
   "Approve": "允許",
   "Wants to Switch Network": "想要切換區塊鍊網絡",

--- a/src/pages/dapp/browser/DappBrowser.tsx
+++ b/src/pages/dapp/browser/DappBrowser.tsx
@@ -46,6 +46,7 @@ export interface DappBrowserRef {
   goForward: () => void;
   reload: () => void;
   getCurrentWebStatus: () => WebInfo | undefined;
+  getWebviewRef: () => (Electron.WebviewTag & HTMLWebViewElement) | null;
 }
 
 const DappBrowser = forwardRef<DappBrowserRef, DappBrowserProps>((props: DappBrowserProps, ref) => {
@@ -95,6 +96,12 @@ const DappBrowser = forwardRef<DappBrowserRef, DappBrowserProps>((props: DappBro
         webviewURL: webviewRef.current?.getURL(),
       };
     },
+    getWebviewRef: () => {
+      if (!isDOMReady) {
+        return null;
+      }
+      return webviewRef.current;
+    }
   }));
 
   const [txEvent, setTxEvent] = useState<

--- a/src/pages/dapp/components/AddressBar/AddressBar.tsx
+++ b/src/pages/dapp/components/AddressBar/AddressBar.tsx
@@ -1,16 +1,19 @@
 import * as React from 'react';
-import {
+import Icon, {
   ArrowLeftOutlined,
   ArrowRightOutlined,
   CloseOutlined,
   LoadingOutlined,
+  MoreOutlined,
   ReloadOutlined,
 } from '@ant-design/icons';
-import { Button, Input, Spin } from 'antd';
+import { Button, Dropdown, Input, Menu, Spin } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { IconBookmarkFilled, IconBookmarkNormal } from '../../../../svg/IconBookmark';
 import ChainSelect from '../ChainSelect';
 import './style.less';
+
+type MoreButtonEventName = 'cleanCache'
 
 interface IButtonStates {
   isLoading: boolean;
@@ -25,6 +28,8 @@ interface IButtonStates {
   isBookmarkButtonHighlighted: boolean;
 
   isExitButtonDisabled: boolean;
+
+  isMoreButtonDisabled: boolean;
 }
 
 interface IAddressBarProps {
@@ -35,6 +40,7 @@ interface IAddressBarProps {
     onRefreshButtonClick: () => void;
     onBookmarkButtonClick: () => void;
     onExitButtonClick: () => void;
+    onMoreButtonClick: (name: MoreButtonEventName, value: any) => void;
   };
   value: string;
   onInputChange: (value: string) => void;
@@ -107,6 +113,22 @@ const AddressBar = (props: IAddressBarProps) => {
         disabled={buttonStates.isExitButtonDisabled}
         onClick={buttonCallbacks.onExitButtonClick}
       />
+      <Dropdown
+        disabled={buttonStates.isMoreButtonDisabled}
+        overlay={(
+          <Menu onClick={() => {
+            buttonCallbacks.onMoreButtonClick('cleanCache', null);
+          }}>
+            <Menu.Item key="1">
+              {t('dapp.clearCache')}
+            </Menu.Item>
+          </Menu>)}>
+        <Button
+          type="link"
+          icon={<MoreOutlined />}
+          disabled={buttonStates.isMoreButtonDisabled}
+        />
+      </Dropdown>
     </div>
   );
 };

--- a/src/pages/dapp/components/AddressBar/AddressBar.tsx
+++ b/src/pages/dapp/components/AddressBar/AddressBar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Icon, {
+import {
   ArrowLeftOutlined,
   ArrowRightOutlined,
   CloseOutlined,

--- a/src/pages/dapp/dapp.tsx
+++ b/src/pages/dapp/dapp.tsx
@@ -178,7 +178,7 @@ const DappPage = () => {
           onRefreshButtonClick: () => {
             browserRef.current?.reload();
           },
-          onMoreButtonClick: async (name, value) => {
+          onMoreButtonClick: async (name) => {
             if (name === 'cleanCache') {
               const webRef = browserRef.current?.getWebviewRef();
               const webId = webRef?.getWebContentsId();

--- a/src/pages/dapp/dapp.tsx
+++ b/src/pages/dapp/dapp.tsx
@@ -22,6 +22,8 @@ import { AnalyticsService } from '../../service/analytics/AnalyticsService';
 import CronosDAppsTab from './components/Tabs/CronosDAppsTab';
 import ChainConfigTab from './components/Tabs/ChainConfigTab';
 
+const remote = window.require('@electron/remote');
+
 const { Header, Content } = Layout;
 const { TabPane } = Tabs;
 
@@ -78,6 +80,7 @@ const DappPage = () => {
   const setPageLock = useSetRecoilState(pageLockState);
   const currentSession = useRecoilValue(sessionState);
   const [selectedDapp, setSelectedDapp] = useState<Dapp>();
+  const [initialDapp, setInitialDapp] = useState('');
   const [selectedURL, setSelectedURL] = useState('');
   const [selectedDomain, setSelectedDomain] = useState('');
   const [t] = useTranslation();
@@ -163,6 +166,7 @@ const DappPage = () => {
           isBookmarkButtonDisabled: false,
           isBookmarkButtonHighlighted: bookmarkButtonHighlighted,
           isExitButtonDisabled: shouldShowBrowser === false,
+          isMoreButtonDisabled: shouldShowBrowser === false,
         }}
         buttonCallbacks={{
           onBackButtonClick: () => {
@@ -174,7 +178,32 @@ const DappPage = () => {
           onRefreshButtonClick: () => {
             browserRef.current?.reload();
           },
-          onBookmarkButtonClick: () => {
+          onMoreButtonClick: async (name, value) => {
+            if (name === 'cleanCache') {
+              const webRef = browserRef.current?.getWebviewRef();
+              const webId = webRef?.getWebContentsId();
+              const webContents: Electron.WebContents = remote.webContents.fromId(webId);
+              // clean the initial dapp's cache incase of jump
+              await webContents.session.clearStorageData({
+                origin: initialDapp,
+              });
+              await webContents.session.clearStorageData({
+                origin: webRef?.getURL(),
+              });
+
+              setSelectedDapp(undefined);
+              setSelectedURL('');
+              setAddressBarValue('');
+              setWebviewState('idle');
+              setWebviewNavigationState({
+                canGoBack: false,
+                canGoForward: false,
+                canRefresh: false,
+              });
+            }
+          },
+          onBookmarkButtonClick: async () => {
+
             const bookMarkInfo = browserRef.current?.getCurrentWebStatus();
             if (!bookMarkInfo?.title || !bookMarkInfo.webviewURL) {
               return;
@@ -270,6 +299,7 @@ const DappPage = () => {
                           }
 
                           setSelectedDapp(dapp);
+                          setInitialDapp(dapp.url);
                         }}
                       >
                         <div className="logo">
@@ -289,6 +319,7 @@ const DappPage = () => {
               <CronosDAppsTab
                 onClickDapp={dapp => {
                   setSelectedURL(dapp.link);
+                  setInitialDapp(dapp.link);
                 }}
               />
             </TabPane>


### PR DESCRIPTION
This operation will clean the DApp site's `appcache`, `cookies`, `filesystem`, `indexdb`, `localstorage`, `shadercache`, `websql`, `serviceworkers`, `cachestorage`, reset all its states.

<img width="1392" alt="image" src="https://user-images.githubusercontent.com/91446598/200469060-be812e2e-60fc-4bfc-b978-f0a08f717e6c.png">

