### PR TITLE
Fix: New restriction on validator API

### DIFF
--- a/src/service/rpc/ChainIndexingAPI.spec.ts
+++ b/src/service/rpc/ChainIndexingAPI.spec.ts
@@ -142,7 +142,7 @@ describe('Testing ChainIndexingApi', () => {
   it('should return estimated rewards for a user account, , apy = 10%, period = 12 Months', async () => {
     const nodeRpcService = ChainIndexingAPI.init('https://crypto.org/explorer/api/v1');
     moxios.wait(() => {
-      const validatorListReq = moxios.requests.get('get', 'validators?limit=1000000');
+      const validatorListReq = moxios.requests.get('get', 'validators?limit=1000');
       const accountInfoReq = moxios.requests.get(
         'get',
         'accounts/cro1gaf3jqqzvrxvgc4u4vr6x0tlf6kcm703zqa34a',
@@ -327,7 +327,7 @@ describe('Testing ChainIndexingApi', () => {
   it('should return estimated rewards for a user account, apy = 10%, period = 6 Months', async () => {
     const nodeRpcService = ChainIndexingAPI.init('https://crypto.org/explorer/api/v1');
     moxios.wait(() => {
-      const validatorListReq = moxios.requests.get('get', 'validators?limit=1000000');
+      const validatorListReq = moxios.requests.get('get', 'validators?limit=1000');
       const accountInfoReq = moxios.requests.get(
         'get',
         'accounts/cro1gaf3jqqzvrxvgc4u4vr6x0tlf6kcm703zqa34a',

--- a/src/service/rpc/ChainIndexingAPI.ts
+++ b/src/service/rpc/ChainIndexingAPI.ts
@@ -35,6 +35,8 @@ import { croNftApi, MintByCDCRequest } from './NftApi';
 import { splitToChunks } from '../../utils/utils';
 import { UserAsset } from '../../models/UserAsset';
 
+const VALIDATOR_FETCH_LIMIT = 1000;
+
 export interface IChainIndexingAPI {
   fetchAllTransferTransactions(
     baseAssetSymbol: string,
@@ -167,7 +169,7 @@ export class ChainIndexingAPI implements IChainIndexingAPI {
     const transferListResponse = await this.axiosClient.get<TransferListResponse>(
       `/accounts/${address}/messages?order=height.desc&filter.msgType=${msgType.join(
         ',',
-      )}&limit=1000`,
+      )}&limit=${VALIDATOR_FETCH_LIMIT}`,
     );
 
     function getStatus(transfer: TransferResult) {
@@ -459,7 +461,7 @@ export class ChainIndexingAPI implements IChainIndexingAPI {
 
   private async getValidatorDetails(validatorAddr: string) {
     const validatorList = await this.axiosClient.get<ValidatorListResponse>(
-      'validators?limit=1000000',
+      `validators?limit=${VALIDATOR_FETCH_LIMIT}`,
     );
 
     if (validatorList.data.pagination.total_page > 1) {
@@ -481,9 +483,8 @@ export class ChainIndexingAPI implements IChainIndexingAPI {
 
   public async getValidatorsDetail(validatorAddrList: string[]) {
     const recentBlocks = '100';
-    const limit = '10000';
     const validatorList = await this.axiosClient.get<ValidatorListResponse>(
-      `validators?recentBlocks=${recentBlocks}&limit=${limit}`,
+      `validators?recentBlocks=${recentBlocks}&limit=${VALIDATOR_FETCH_LIMIT}`,
     );
 
     if (validatorList.data.pagination.total_page > 1) {
@@ -501,7 +502,7 @@ export class ChainIndexingAPI implements IChainIndexingAPI {
 
   public async getValidatorsAverageApy(validatorAddrList: string[]) {
     const validatorList = await this.axiosClient.get<ValidatorListResponse>(
-      'validators?limit=1000000',
+      `validators?limit=${VALIDATOR_FETCH_LIMIT}`,
     );
 
     if (validatorList.data.pagination.total_page > 1) {


### PR DESCRIPTION
## Issue
The API fetching validators is returning `400`, causing some of the service failure regarding to Staking.
https://crypto.org/explorer/api/v1/validators?limit=100000

This API has applied a new restriction on param `limit`. The maximum value is now `1000`. 
We were using `1000000` on Desktop Wallet.



It’s working normally with `limit` lower than `1000`.
https://crypto.org/explorer/api/v1/validators?limit=1000

