### PR TITLE
fix: only support http/https protocol in the dapp browser

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -12,6 +12,7 @@ import Store from 'electron-store';
 import { APP_PROTOCOL_NAME } from '../src/config/StaticConfig';
 
 import { getGAnalyticsCode, getUACode, actionEvent, transactionEvent, pageView } from './UsageAnalytics';
+import { isValidURL } from './utils';
 
 remoteMain.initialize();
 
@@ -191,6 +192,16 @@ app.on('ready', async function () {
     autoUpdater.checkForUpdatesAndNotify();
   }
 });
+
+app.on('web-contents-created', (event, contents) => {
+  if (contents.getType() == 'webview') {
+    contents.on('will-navigate', (event, url) => {
+      if (!isValidURL(url)) {
+        event.preventDefault();
+      }
+    })
+  }
+})
 
 ipcMain.handle('get_auto_update_expire_time', (event) => {
   return store.get('autoUpdateExpireTime');

--- a/electron/utils.ts
+++ b/electron/utils.ts
@@ -1,0 +1,11 @@
+export function isValidURL(str: string) {
+    const regex = new RegExp(
+      '^(http[s]?:\\/\\/(www\\.)?|www\\.){1}([0-9A-Za-z-\\.@:%_+~#=]+)+((\\.[a-zA-Z]{2,3})+)(/(.)*)?(\\?(.)*)?', // lgtm [js/redos]
+    );
+  
+    const withoutPrefixRegex = new RegExp(
+      '^([0-9A-Za-z-\\.@:%_+~#=]+)+((\\.[a-zA-Z]{2,3})+)(/(.)*)?(\\?(.)*)?', // lgtm [js/redos]
+    );
+    return regex.test(str) || withoutPrefixRegex.test(str);
+}
+  


### PR DESCRIPTION
Background: https://www.cybersecurity-help.cz/vdb/SB2023091322

Solutions from: https://github.com/electron/electron/issues/1378#issuecomment-265207386

- Only allow HTTP and HTTPS protocol, and block others
- `isValidURL` is a method copied from `src` folder, seems no way to share code between main and renderer process, so just make a simple duplication here