### PR TITLE
Problem: Update EVM minimum gas price

### DIFF
--- a/src/components/GasCustomize/EVM/GasModal.tsx
+++ b/src/components/GasCustomize/EVM/GasModal.tsx
@@ -186,7 +186,7 @@ const ModalBody = (props: {
           }}
         >
           <div style={{ color: '#7B849B' }}>{t('estimate-time')}</div>
-          <div>{isUsingCustomGas ? `~1~24 ${t('general.hours').toLowerCase()}` : '6s'}</div>
+          <div>{isUsingCustomGas ? `~1~24 ${t('general.hours').toLowerCase()}` : '30s'}</div>
         </div>
         <Form.Item
           style={{

--- a/src/config/StaticConfig.ts
+++ b/src/config/StaticConfig.ts
@@ -257,9 +257,8 @@ export type WalletConfig = {
 export const FIXED_DEFAULT_FEE = String(10_000);
 export const FIXED_DEFAULT_GAS_LIMIT = String(300_000);
 export const DEFAULT_IBC_TRANSFER_TIMEOUT = 3_600_000;
-
-export const EVM_MINIMUM_GAS_PRICE = String(42_000_000_000);
-export const EVM_MINIMUM_GAS_LIMIT = String(42_000);
+export const EVM_MINIMUM_GAS_PRICE = String(10_000_000_000_000);
+export const EVM_MINIMUM_GAS_LIMIT = String(50_000);
 
 export const NFT_IMAGE_DENOM_SCHEMA = {
   title: 'Asset Metadata',


### PR DESCRIPTION
## Background
Default EVM minimum gas price & gas limit settings are no longer processable for existing transfer usage. 

### Update
`GasPrice`: `42_000_000_000` => `10_000_000_000_000`
`GasLimit`: `42_000` => `50_000`