### PR TITLE
Problem: formatting in eth.models

### DIFF
--- a/src/service/rpc/models/eth.models.ts
+++ b/src/service/rpc/models/eth.models.ts
@@ -43,7 +43,7 @@ export interface TransactionData {
   to: string;
   to_metadata: {
     is_contract: boolean;
-  }
+  };
   type: number;
   value: string;
   decimal?: number;


### PR DESCRIPTION
Missing semicolon after the object type definition for `from_metadata`. TypeScript interface properties should end with semicolons for consistency with the rest of the file. The same issue exists for `to_metadata` on line 44-46.

👮🏻👮🏻👮🏻 !!!! REFERENCE THE PROBLEM YOUR ARE SOLVING IN THE PR TITLE AND DESCRIBE YOUR SOLUTION HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [ ] Have you read the [CONTRIBUTING.md](/CONTRIBUTING.md)?
- [ ] Have you rebased your work on top of the latest `dev`? 
- [ ] Does your PR follow the [Conventional Commits Guide](https://www.conventionalcommits.org/)?
- [ ] Have you checked your code compiles? (`yarn build`)
- [ ] Have you included tests for any non-trivial functionality?
- [ ] Have you followed the [Multi-Language Content Management Guide](/CONTENT_MANAGEMENT.md)?
- [ ] Have you checked your code passes the unit tests? (`yarn test`)
- [ ] Have you checked your code formatting is correct? (`yarn lint:js`)
- [ ] If you added any dependencies, have you checked they do not contain any known vulnerabilities? (`yarn audit`)
- [ ] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](/CONTRIBUTING.md#developer-certificate-of-origin).

Thank you for your code, it's appreciated! :)
